### PR TITLE
Move dynamic components into subdirectory (Again)

### DIFF
--- a/components/Template.tsx
+++ b/components/Template.tsx
@@ -8,10 +8,6 @@ import { tablet, mobile } from "./layout/Breakpoints"
 import { Markdown } from "./layout/Markdown"
 import { GoogleTag } from "./GoogleTag"
 
-// Monobase doesn't really have support for loading an index file...
-// so we just import a bootstrap script in the template.
-import "./bootstrap"
-
 const Body = styled.body`
     font-family: Colfax, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans,
         Droid Sans, Helvetica Neue, sans-serif;

--- a/components/bootstrap.ts
+++ b/components/bootstrap.ts
@@ -1,4 +1,11 @@
+import { Dynamic } from "monobase"
 import { highlight } from "./highlighter"
+
+// Monobase doesn't support compiling additional scripts for client-side use
+// other than the components.js file. So we export an empty Dynamic()
+// component so this bootstrap script is picked up by the build and run
+// on the client.
+export default Dynamic(() => null)
 
 if (typeof document !== "undefined") {
     document.addEventListener("DOMContentLoaded", () => {

--- a/components/layout/Markdown.tsx
+++ b/components/layout/Markdown.tsx
@@ -225,7 +225,7 @@ export const MarkdownStyles = styled.div`
     a {
         color: inherit;
     }
-    a:not(.DocRefTag),
+    a,
     ol a {
         color: #05f;
         transition: opacity 0.2s ease;


### PR DESCRIPTION
<i>Re-opening #11. I hadn't noticed that the bootstrap.ts script wasn't being loaded previously which caused the syntax highlighting to break.</i>

We're currently shipping the entire framer.data.js JSON blob up to the client for no reason. This was due to the components/index.ts file exporting all components including dynamic ones. Monobase then needs to include the index.ts file in the build.

I've now pulled out the dynamic exports into their own subdirectory under components/layout/dynamic so they're no longer included in the components/index.ts files. This reduces the JavaScript bundle by half. I've also remove the contributing images as they're no longer used.