### PR TITLE
Fix broken `<Ref>` links

### DIFF
--- a/api/linkify.ts
+++ b/api/linkify.ts
@@ -25,9 +25,9 @@ const pathById: { [id: string]: string } = {}
 console.log("Updating TSDoc @link references")
 
 parsed.forEach($ => {
-    $("[data-permalink-id]").each((_, el) => {
-        const { permalinkId, permalinkPath } = $(el).data()
-        pathById[permalinkId] = permalinkPath
+    $("[data-permalink-ref][data-permalink-path]").each((_, el) => {
+        const { permalinkRef, permalinkPath } = $(el).data()
+        pathById[permalinkRef] = permalinkPath
     })
 })
 

--- a/components/documentation/APIClass.tsx
+++ b/components/documentation/APIClass.tsx
@@ -29,7 +29,7 @@ export const APIClassElement: React.FunctionComponent<ClassModel & {skipnav?: bo
         <>
             <Grid className={"grid-section-h2 " + apiClassName("class", props, rest)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.name + "()"} skipnav={props.skipnav} />
+                    <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} skipnav={props.skipnav} />
                     {props.fullname || "Unknown Name"} <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />

--- a/components/documentation/APIEnum.tsx
+++ b/components/documentation/APIEnum.tsx
@@ -19,7 +19,7 @@ export const APIEnumElement: React.FunctionComponent<EnumModel & {skipnav?: bool
         <>
             <Grid className={"grid-section-h2 " + apiClassName("enum", props)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.fullname} skipnav={props.skipnav} />
+                    <Permalink id={permalinkId(props)} name={props.fullname} modelId={props.id} skipnav={props.skipnav} />
                     {props.fullname || "Unknown Name"} <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />
@@ -37,7 +37,7 @@ export const APIEnumFieldElement: React.FunctionComponent<BaseModel> = props => 
     return (
         <Grid className="framer-enum-field framer-api">
             <h3>
-                <Permalink id={permalinkId(props)} name={props.fullname} skipnav />
+                <Permalink id={permalinkId(props)} name={props.fullname} modelId={props.id} skipnav />
                 {props.fullname}
             </h3>
             <APIOverviewElement {...props} />

--- a/components/documentation/APIFunction.tsx
+++ b/components/documentation/APIFunction.tsx
@@ -17,7 +17,7 @@ import { apiClassName, permalinkId } from "./helpers"
 export const APIFunctionElement: React.FunctionComponent<MethodModel> = props => {
     const signatures = [props].concat(props.overloads).map(method => (
         <h3 key={method.id}>
-            <Permalink id={permalinkId(props)} name={props.name + "()"} skipnav />
+            <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} skipnav />
             <code className="language-typescript">{method.signature}</code> <ReleaseBadge {...props} />
         </h3>
     ))

--- a/components/documentation/APIInterface.tsx
+++ b/components/documentation/APIInterface.tsx
@@ -29,7 +29,7 @@ export const APIInterfaceElement: React.FunctionComponent<InterfaceModel & {skip
         <>
             <Grid className={"grid-section-h2 " + apiClassName("interface", props, rest)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.name} skipnav={props.skipnav} />
+                    <Permalink id={permalinkId(props)} name={props.name} modelId={props.id} skipnav={props.skipnav} />
                     {props.fullname || "Unknown Name"} <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />

--- a/components/documentation/APIMethod.tsx
+++ b/components/documentation/APIMethod.tsx
@@ -18,7 +18,7 @@ import { apiClassName, permalinkId } from "./helpers"
 export const APIMethodElement: React.FunctionComponent<MethodModel> = props => {
     const signatures = [props].concat(props.overloads).map(method => (
         <h3 key={method.id}>
-            <Permalink id={permalinkId(props)} name={props.name + "()"} skipnav />
+            <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} skipnav />
             <Signature signature={method.signature} />
             <ReleaseBadge {...props} />
         </h3>

--- a/components/documentation/APINamespace.tsx
+++ b/components/documentation/APINamespace.tsx
@@ -36,7 +36,7 @@ export const APINamespaceElement: React.FunctionComponent<NamespaceModel & {skip
         header = (
             <Grid className={"grid-section-h2 " + apiClassName("namespace", props, rest)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.name} skipnav={props.skipnav} />
+                    <Permalink id={permalinkId(props)} name={props.name} modelId={props.id} skipnav={props.skipnav} />
                     {props.name || "Unknown Name"} <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />

--- a/components/documentation/APIProperty.tsx
+++ b/components/documentation/APIProperty.tsx
@@ -14,7 +14,7 @@ export const APIPropertyElement: React.FunctionComponent<PropertyModel> = props 
     return (
         <Grid className={apiClassName("property", props, React.Children.toArray(props.children))}>
             <h3>
-                <Permalink id={permalinkId(props)} name={props.name} skipnav />
+                <Permalink id={permalinkId(props)} name={props.name} modelId={props.id} skipnav />
                 <Signature signature={props.signature} />
                 <ReleaseBadge {...props} />
             </h3>

--- a/components/documentation/APIReactComponent.tsx
+++ b/components/documentation/APIReactComponent.tsx
@@ -26,7 +26,7 @@ export const APIReactComponentElement: React.FunctionComponent<ClassModel> = pro
         <>
             <Grid className={"grid-section-h2 " + apiClassName("react-component", props, rest)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.name + "()"} />
+                    <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} />
                     {props.name || "Unknown"} Component <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />

--- a/components/documentation/APIVariable.tsx
+++ b/components/documentation/APIVariable.tsx
@@ -13,7 +13,7 @@ export const APIVariableElement: React.FunctionComponent<PropertyModel> = props 
     return (
         <Grid className={apiClassName("variable", props, React.Children.toArray(props.children))}>
             <h3>
-                <Permalink id={permalinkId(props)} name={props.name} skipnav />
+                <Permalink id={permalinkId(props)} name={props.name} modelId={props.id} skipnav />
                 <code className="language-typescript">{props.signature || "Unknown Name"}</code>{" "}
                 <ReleaseBadge {...props} />
             </h3>

--- a/components/layout/Permalink.tsx
+++ b/components/layout/Permalink.tsx
@@ -136,9 +136,10 @@ const PermalinkSpan = styled.span`
     }
 `
 
-export const Permalink: React.FunctionComponent<{ id: string; name: string; skipnav?: boolean }> = ({
+export const Permalink: React.FunctionComponent<{ id: string; name: string; modelId?: string, skipnav?: boolean }> = ({
     id,
     name,
+    modelId,
     skipnav = false,
 }) => {
     if (!id && !name) return null
@@ -151,17 +152,18 @@ export const Permalink: React.FunctionComponent<{ id: string; name: string; skip
                 <CopyToClipboard title="Copy Link" className="copy" href={`#${id}`}>
                     #
                 </CopyToClipboard>
-                <PermalinkAnchor id={id} />
+                <PermalinkAnchor id={id} modelId={modelId} />
             </PermalinkSpan>
         </>
     )
 }
 
 /**
- * Puts a linkable anchor on the page, see <RefAnchor />
+ * Puts a linkable anchor on the page, see <RefAnchor />. The `modelId` should
+ * be the API model identifier, used to link up the <Ref> component.
  */
-export const PermalinkAnchor: React.FunctionComponent<{ id: string }> = ({ id }) => {
+export const PermalinkAnchor: React.FunctionComponent<{ id: string, modelId?: string }> = ({ id, modelId }) => {
     // Offset the permalink from its position in the DOM to give some breathing room.
     const style: React.CSSProperties = { position: "absolute", top: -60, display: "block" }
-    return <span id={id} data-permalink-id={id} data-permalink-path={`${usePath()}#${id}`} aria-hidden style={style} />
+    return <span id={id} data-permalink-id={id} data-permalink-path={`${usePath()}#${id}`} data-permalink-ref={modelId} aria-hidden style={style} />
 }

--- a/components/layout/Ref.tsx
+++ b/components/layout/Ref.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { FramerAPIContext } from "../contexts/FramerAPIContext"
-import { PermalinkAnchor } from "../layout/Permalink"
+import { permalinkId } from "../documentation/helpers"
+import { PermalinkAnchor } from "./Permalink"
 
 /** Allows the use of paths to .mdx pages (otherwise the parser gets confused) */
 export const Ref: React.FunctionComponent<{ name: string }> = ({ name, children }) => {
@@ -13,6 +14,6 @@ export const Ref: React.FunctionComponent<{ name: string }> = ({ name, children 
 export const RefAnchor: React.FunctionComponent<{name: string}> = ({name}) => {
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(name)
-    const ref = model ? model.id : name
-    return <PermalinkAnchor id={ref} />
+    const id = model ? permalinkId(model) : name
+    return <PermalinkAnchor id={id} modelId={model ? model.id : undefined} />
 }


### PR DESCRIPTION
These use the underlying model id so we needed to pass this into `<Permalink>` as well as the new url hash string.