### PR TITLE
Feature/upgrade api extractor

### DIFF
--- a/api/__tests__/walker.test.ts
+++ b/api/__tests__/walker.test.ts
@@ -1,12 +1,11 @@
 import * as json from "../__fixtures__/example.api.json"
-import { ApiPackage, ApiItem, ReleaseTag } from "@microsoft/api-extractor"
+import { ApiPackage, ApiItem, ReleaseTag } from "@microsoft/api-extractor-model"
 import { walk } from "../walker"
 
 describe("walk", () => {
     function createApiPackage() {
         return ApiItem.deserialize(json as any) as ApiPackage
     }
-
 
     it("should generate ids", () => {
         const ids: string[] = []

--- a/api/generator.ts
+++ b/api/generator.ts
@@ -18,7 +18,7 @@
 import * as fs from "fs"
 import * as path from "path"
 import * as assert from "assert"
-import { ApiModel, ReleaseTag as ApiReleaseTag } from "@microsoft/api-extractor"
+import { ApiModel, ReleaseTag as ApiReleaseTag } from "@microsoft/api-extractor-model"
 import { walk } from "./walker"
 import { RawAPIData, Kind, AnyRawModel } from "./types"
 

--- a/api/types.ts
+++ b/api/types.ts
@@ -1,5 +1,5 @@
 /**
- * Subset of types found in @microsoft/api-extractor
+ * Subset of types found in @microsoft/api-extractor-model
  */
 export enum Kind {
     Class = "Class",

--- a/api/walker.ts
+++ b/api/walker.ts
@@ -22,7 +22,7 @@ import {
     ApiDeclaredItem,
     ApiDocumentedItem,
     ReleaseTag as ApiReleaseTag,
-} from "@microsoft/api-extractor"
+} from "@microsoft/api-extractor-model"
 import {
     RawBaseModel,
     RawClassModel,

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
     "version": "1.0.0",
     "private": true,
     "devDependencies": {
-        "@microsoft/api-extractor": "7.0.13",
-        "@microsoft/tsdoc": "0.12.4",
+        "@microsoft/api-extractor": "^7.1.5",
+        "@microsoft/api-extractor-model": "^7.1.0",
+        "@microsoft/tsdoc": "^0.12.9",
         "@types/chalk": "^2.2.0",
         "@types/cheerio": "^0.22.11",
         "@types/classnames": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
     "version": "1.0.0",
     "private": true,
     "devDependencies": {
-        "@microsoft/api-extractor": "^7.1.5",
         "@microsoft/api-extractor-model": "^7.1.0",
-        "@microsoft/tsdoc": "^0.12.9",
+        "@microsoft/tsdoc": "0.12.9",
         "@types/chalk": "^2.2.0",
         "@types/cheerio": "^0.22.11",
         "@types/classnames": "^2.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,24 +794,34 @@
   version "1.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-1.0.0-alpha.6.tgz#2ae87d75c1f2cf6d4a79d863bfd1ce441dd34fd5"
 
-"@microsoft/api-extractor@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.0.13.tgz#0f5118af66c2c09d1b32dade63b32e8d18195f58"
+"@microsoft/api-extractor-model@7.1.0", "@microsoft/api-extractor-model@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.1.0.tgz#57e9805ba0f2322dd12945bb0588eeda522519cd"
+  integrity sha512-DvaJ1fEpwega9TVMR4xR0jeNV/9JHNMxN/t8TuBftZHSLZzTczh8HyqyFxKo2IwDDCoZy5FmXZsq/vo5JQvRMQ==
   dependencies:
-    "@microsoft/node-core-library" "3.9.0"
-    "@microsoft/ts-command-line" "4.2.3"
-    "@microsoft/tsdoc" "0.12.4"
+    "@microsoft/node-core-library" "3.13.0"
+    "@microsoft/tsdoc" "0.12.9"
     "@types/node" "8.5.8"
-    "@types/z-schema" "3.16.31"
+
+"@microsoft/api-extractor@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.1.5.tgz#d739db944986b5b51255cc2bcc30d53678ab68ec"
+  integrity sha512-MalxwkoaIKIc9vHMHFuGnM8egVNKBVI4OUr5Af97KvkO4NsshaHylIBvmxGtqM03G7ch1C3BL2oAF79a6TaFPw==
+  dependencies:
+    "@microsoft/api-extractor-model" "7.1.0"
+    "@microsoft/node-core-library" "3.13.0"
+    "@microsoft/ts-command-line" "4.2.4"
+    "@microsoft/tsdoc" "0.12.9"
     colors "~1.2.1"
     lodash "~4.17.5"
     resolve "1.8.1"
-    typescript "~3.1.6"
-    z-schema "~3.18.3"
+    source-map "~0.6.1"
+    typescript "~3.4.3"
 
-"@microsoft/node-core-library@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.9.0.tgz#a999c15c45707bfd5e2329518e00cb2c8d33b55c"
+"@microsoft/node-core-library@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.13.0.tgz#ba24e16182149dc817bf52a886d22aced5cd8070"
+  integrity sha512-mnsL/1ikVWHl8sPNssavaAgtUaIM3hkQ8zeySuApU5dNmsMPzovJPfx9m5JGiMvs1v5QNAIVeiS9jnWwe/7anw==
   dependencies:
     "@types/fs-extra" "5.0.4"
     "@types/jju" "~1.4.0"
@@ -822,18 +832,20 @@
     jju "~1.4.0"
     z-schema "~3.18.3"
 
-"@microsoft/ts-command-line@4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.2.3.tgz#20d6a1684148b9fc0df25ee7335c3bb227d47d4f"
+"@microsoft/ts-command-line@4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.2.4.tgz#42fbd5dac0eb530b338867ec62e86a463d8280d6"
+  integrity sha512-aRKhg+Tpxx4PSRYzFmv+bMsoMFi2joE6tONlTHB2MER1mivS0qb8uJh1SvrjzeshD6sASlaQxgADRIdHyXBCWw==
   dependencies:
     "@types/argparse" "1.0.33"
     "@types/node" "8.5.8"
     argparse "~1.0.9"
     colors "~1.2.1"
 
-"@microsoft/tsdoc@0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.4.tgz#42159590f2b12e23f6028c70aed41dd5b11275c3"
+"@microsoft/tsdoc@0.12.9", "@microsoft/tsdoc@^0.12.9":
+  version "0.12.9"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.9.tgz#f92538bebf649b1b9d00bdd34a9c9971aef17d01"
+  integrity sha512-sDhulvuVk65eMppYOE6fr6mMI6RUqs53KUg9deYzNCBpP+2FhR0OFB5innEfdtSedk0LK+1Ppu6MxkfiNjS/Cw==
 
 "@popmotion/easing@^1.0.1":
   version "1.0.2"
@@ -7616,9 +7628,10 @@ typescript@^3.1.6:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
 
-typescript@~3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+typescript@~3.4.3:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,7 @@
   version "1.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-1.0.0-alpha.6.tgz#2ae87d75c1f2cf6d4a79d863bfd1ce441dd34fd5"
 
-"@microsoft/api-extractor-model@7.1.0", "@microsoft/api-extractor-model@^7.1.0":
+"@microsoft/api-extractor-model@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.1.0.tgz#57e9805ba0f2322dd12945bb0588eeda522519cd"
   integrity sha512-DvaJ1fEpwega9TVMR4xR0jeNV/9JHNMxN/t8TuBftZHSLZzTczh8HyqyFxKo2IwDDCoZy5FmXZsq/vo5JQvRMQ==
@@ -802,21 +802,6 @@
     "@microsoft/node-core-library" "3.13.0"
     "@microsoft/tsdoc" "0.12.9"
     "@types/node" "8.5.8"
-
-"@microsoft/api-extractor@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.1.5.tgz#d739db944986b5b51255cc2bcc30d53678ab68ec"
-  integrity sha512-MalxwkoaIKIc9vHMHFuGnM8egVNKBVI4OUr5Af97KvkO4NsshaHylIBvmxGtqM03G7ch1C3BL2oAF79a6TaFPw==
-  dependencies:
-    "@microsoft/api-extractor-model" "7.1.0"
-    "@microsoft/node-core-library" "3.13.0"
-    "@microsoft/ts-command-line" "4.2.4"
-    "@microsoft/tsdoc" "0.12.9"
-    colors "~1.2.1"
-    lodash "~4.17.5"
-    resolve "1.8.1"
-    source-map "~0.6.1"
-    typescript "~3.4.3"
 
 "@microsoft/node-core-library@3.13.0":
   version "3.13.0"
@@ -832,17 +817,7 @@
     jju "~1.4.0"
     z-schema "~3.18.3"
 
-"@microsoft/ts-command-line@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.2.4.tgz#42fbd5dac0eb530b338867ec62e86a463d8280d6"
-  integrity sha512-aRKhg+Tpxx4PSRYzFmv+bMsoMFi2joE6tONlTHB2MER1mivS0qb8uJh1SvrjzeshD6sASlaQxgADRIdHyXBCWw==
-  dependencies:
-    "@types/argparse" "1.0.33"
-    "@types/node" "8.5.8"
-    argparse "~1.0.9"
-    colors "~1.2.1"
-
-"@microsoft/tsdoc@0.12.9", "@microsoft/tsdoc@^0.12.9":
+"@microsoft/tsdoc@0.12.9":
   version "0.12.9"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.9.tgz#f92538bebf649b1b9d00bdd34a9c9971aef17d01"
   integrity sha512-sDhulvuVk65eMppYOE6fr6mMI6RUqs53KUg9deYzNCBpP+2FhR0OFB5innEfdtSedk0LK+1Ppu6MxkfiNjS/Cw==
@@ -869,10 +844,6 @@
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
   dependencies:
     defer-to-connect "^1.0.1"
-
-"@types/argparse@1.0.33":
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
 
 "@types/babel__core@^7.1.0":
   version "7.1.0"
@@ -1419,7 +1390,7 @@ arg@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
 
-argparse@^1.0.7, argparse@~1.0.9:
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
@@ -5081,7 +5052,7 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10, lodash@~4.17.5:
+lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -6693,12 +6664,6 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  dependencies:
-    path-parse "^1.0.5"
-
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
@@ -7627,11 +7592,6 @@ typedarray@^0.0.6:
 typescript@^3.1.6:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
-
-typescript@~3.4.3:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Implements https://github.com/framer/company/issues/13173
Dependant on https://github.com/framer/motion/pull/141 and https://github.com/framer/FramerStudio/pull/2421

### What was done
* Replace the api-extractor dependency with api-extractor-model, because that's the only thing we use
* Upgrade TSDoc to support some stuff that gave errors otherwise
