### PR TITLE
Add new docs for the url() helper function

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -22,6 +22,7 @@ export const Navigation: React.FunctionComponent = () => {
             <MenuItem className="stack" href="/pages/utilities.mdx" title="Utilities" />
 
             <SubTitle name="Framer X" />
+            <MenuItem className="assets" href="/pages/assets.mdx" title="Assets" />
             <MenuItem className="data" href="/pages/data.mdx" title="Data" />
             <MenuItem className="canvas-components" href="/pages/canvas-components.mdx" title="CanvasComponents" />
             <MenuItem className="property-controls" href="/pages/property-controls.mdx" title="PropertyControls" />

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -1,0 +1,65 @@
+<!-- 👋 Editing this file? Need help? → https://github.com/framer/api-docs/blob/master/CONTRIBUTING.md -->
+
+import {
+  Template,
+  APIFunctionElement
+} from "../components"
+
+export default Template
+
+# Assets
+
+<span className="lead">
+  Using the <strong>framer/resources</strong> module you can reference any files included in
+  your Framer project from within your code component.
+</span>
+
+Components can use the `url()` function to create a URL that will reference any
+file within your Framer project. This is particularly useful for including
+images and other media from code.
+
+---
+
+## Functions
+
+<APIFunctionElement
+    id={"(function:url)"}
+    parentId={null}
+    name={"url()"}
+    fullname={"url()"}
+    kind={"Function"}
+    releaseTag={"public"}
+    tsdoc={""}
+    signature={"url(path: string): string"}
+    summaryMarkup={`
+    <p>Generates a URL for the path provided that will work regardless of where
+    the component is being used (e.g. in the Canvas, Preview or Export).</p>
+    <pre><code class="language-jsx">import * as React from &#x22;react&#x22;\nimport { Frame } from &#x22;framer&#x22;\nimport { url } from &#x22;framer/resource&#x22;\n\nconst backgroundImage = url(&#x22;./code/test.png&#x22;)\n\nexport const MyComponent = () =&#x3E; {\n  return &#x3C;Frame background={&#x60;url(\$\{backgroundImage\})&#x60;} size=&#x22;100%&#x22; /&#x3E;\n}\n</code></pre>
+    `}
+    remarksMarkup={""}
+    depreactedMarkup={""}
+    visibility={"public"}
+    kind={"Function"}
+    isStatic={false}
+    returnType="string"
+    returnMarkup="<p>An absolute url for the path within the current project.</p>"
+    overloadIndex={0}
+    overloads={[]}
+    parameters={[
+        {
+            id: "(function:url).(path:parameter)",
+            parentId: null,
+            name: "path",
+            fullname: "path",
+            kind: "Parameter",
+            releaseTag: "public",
+            tsdoc: "",
+            signature: "path: string",
+            summaryMarkup: "<p>A path to a file within the current project relative to the folder root.</p>",
+            remarksMarkup: "",
+            depreactedMarkup: "",
+            visibility: "public",
+            type: "string",
+        }
+    ]}
+/>

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -2,7 +2,9 @@
 
 import {
   Template,
-  APIFunctionElement
+  H3,
+  APIParam,
+  APIParams,
 } from "../components"
 
 export default Template
@@ -22,44 +24,30 @@ images and other media from code.
 
 ## Functions
 
-<APIFunctionElement
-    id={"(function:url)"}
-    parentId={null}
-    name={"url()"}
-    fullname={"url()"}
-    kind={"Function"}
-    releaseTag={"public"}
-    tsdoc={""}
-    signature={"url(path: string): string"}
-    summaryMarkup={`
-    <p>Generates a URL for the path provided that will work regardless of where
-    the component is being used (e.g. in the Canvas, Preview or Export).</p>
-    <pre><code class="language-jsx">import * as React from &#x22;react&#x22;\nimport { Frame } from &#x22;framer&#x22;\nimport { url } from &#x22;framer/resource&#x22;\n\nconst backgroundImage = url(&#x22;./code/test.png&#x22;)\n\nexport const MyComponent = () =&#x3E; {\n  return &#x3C;Frame background={&#x60;url(\$\{backgroundImage\})&#x60;} size=&#x22;100%&#x22; /&#x3E;\n}\n</code></pre>
-    `}
-    remarksMarkup={""}
-    depreactedMarkup={""}
-    visibility={"public"}
-    kind={"Function"}
-    isStatic={false}
-    returnType="string"
-    returnMarkup="<p>An absolute url for the path within the current project.</p>"
-    overloadIndex={0}
-    overloads={[]}
-    parameters={[
-        {
-            id: "(function:url).(path:parameter)",
-            parentId: null,
-            name: "path",
-            fullname: "path",
-            kind: "Parameter",
-            releaseTag: "public",
-            tsdoc: "",
-            signature: "path: string",
-            summaryMarkup: "<p>A path to a file within the current project relative to the folder root.</p>",
-            remarksMarkup: "",
-            depreactedMarkup: "",
-            visibility: "public",
-            type: "string",
-        }
-    ]}
-/>
+<div class="framer-api framer-function">
+
+<H3 id="url"><code class="language-typescript">url(path: string): string</code></H3>
+
+Generates a URL for the path provided that will work regardless of where
+the component is being used (e.g. in the Canvas, Preview or Export).
+
+<APIParams>
+    <APIParam name="path" type="string"><p>A path to a file within the current project relative to the folder root.</p></APIParam>
+    <APIParam name="returns" type="string"><p>A path to a file within the current project relative to the folder root.</p></APIParam>
+</APIParams>
+
+</div>
+
+```jsx highlight(3,5,8)
+import * as React from "react"
+import { Frame } from "framer"
+import { url } from "framer/resource"
+
+const backgroundImage = url("./code/test.png")
+
+export const MyComponent = () => {
+    return <Frame background={`url(${backgroundImage})`} size="100%" />
+}
+```
+
+

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -47,7 +47,7 @@ import { Frame } from "framer"
 import { url } from "framer/resource"
 
 export const MyComponent = () => {
-    return <Frame image={url("./code/test.png")} size="100%" />
+    return <Frame image={url("./code/test.png")} size={"100%"} />
 }
 ```
 

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -28,8 +28,11 @@ images and other media from code.
 
 <H3 id="url"><code class="language-typescript">url(path: string): string</code></H3>
 
+</div>
+<div>
+
 Generates a URL for the path provided that will work regardless of where
-the component is being used (e.g. in the Canvas, Preview or Export).
+the component is being used (for example, in the Canvas, Preview or Export).
 
 <APIParams>
     <APIParam name="path" type="string"><p>A path to a file within the current project relative to the folder root.</p></APIParam>
@@ -38,15 +41,13 @@ the component is being used (e.g. in the Canvas, Preview or Export).
 
 </div>
 
-```jsx highlight(3,5,8)
+```jsx highlight(3,6)
 import * as React from "react"
 import { Frame } from "framer"
 import { url } from "framer/resource"
 
-const backgroundImage = url("./code/test.png")
-
 export const MyComponent = () => {
-    return <Frame background={`url(${backgroundImage})`} size="100%" />
+    return <Frame image={url("./code/test.png")} size="100%" />
 }
 ```
 


### PR DESCRIPTION
This adds a new page under /api/assets that documents the `url()` helper function. Due to this file not being part of the library I created the model manually to ensure the formatting is the same, but it might be easier for maintenance to just write this one out with plain markdown.