### PR TITLE
Add highlight prop to API components

### DIFF
--- a/api/TSDocReactEmitter.ts
+++ b/api/TSDocReactEmitter.ts
@@ -194,7 +194,7 @@ function render<T>(docNode: DocNode | undefined, { createElement, Fragment }: Li
                     "code",
                     {
                         "data-lang": docFencedCode.language,
-                        className: `language-${docFencedCode.language} line-numbers`,
+                        className: `language-${docFencedCode.language}`,
                     },
                     docFencedCode.code
                 )

--- a/api/__tests__/__snapshots__/TSDocReactEmitter.test.ts.snap
+++ b/api/__tests__/__snapshots__/TSDocReactEmitter.test.ts.snap
@@ -71,7 +71,7 @@ Array [
     className="DocFencedCode"
   >
     <code
-      className="language-jsx line-numbers"
+      className="language-jsx"
       data-lang="jsx"
     >
       // Default
@@ -167,7 +167,7 @@ Array [
     className="DocFencedCode"
   >
     <code
-      className="language-jsx line-numbers"
+      className="language-jsx"
       data-lang="jsx"
     >
       const foo = "bar";

--- a/components/RawScript.tsx
+++ b/components/RawScript.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 export class RawScript extends React.Component {
-    count: 0
+    private count = 0
 
     render() {
         this.count++

--- a/components/documentation/APIEnum.tsx
+++ b/components/documentation/APIEnum.tsx
@@ -8,18 +8,24 @@ import { DeprecatedNotice } from "./DeprecatedNotice"
 import { Grid } from "components/layout/Grid"
 import { Permalink } from "../layout/Permalink"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntityExample, APIEntity } from "./types"
 
 /**
  * Renders the documentation for the enum provided including the individual
  * fields.
  * @param props - An EnumModel object.
  */
-export const APIEnumElement: React.FunctionComponent<EnumModel & {skipnav?: boolean}> = props => {
+export const APIEnumElement: React.FunctionComponent<APIEntityExample<EnumModel>> = props => {
     return (
         <>
             <Grid className={"grid-section-h2 " + apiClassName("enum", props)}>
                 <h2>
-                    <Permalink id={permalinkId(props)} name={props.fullname} modelId={props.id} skipnav={props.skipnav} />
+                    <Permalink
+                        id={permalinkId(props)}
+                        name={props.fullname}
+                        modelId={props.id}
+                        skipnav={props.skipnav}
+                    />
                     {props.fullname || "Unknown Name"} <ReleaseBadge {...props} />
                 </h2>
                 <DeprecatedNotice {...props} />
@@ -53,27 +59,27 @@ export const APIEnumFieldElement: React.FunctionComponent<BaseModel> = props => 
  * @param props.overrides - Any members of the EnumModel to override
  * @param props.skipnav - If true hides the item from the navigation
  */
-export const APIEnum: React.FunctionComponent<{ name: string; overrides?: Partial<EnumModel>; skipnav?: boolean }> = props => {
-    const { name, overrides } = props
+export const APIEnum: React.FunctionComponent<APIEntity<EnumModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(name, Kind.Enum)
     if (!model) return <MissingModelWarning name={name} kind={Kind.Enum} />
 
     return (
-        <APIEnumElement {...model} {...overrides} skipnav={props.skipnav}>
+        <APIEnumElement {...model} {...overrides} {...rest}>
             {props.children}
         </APIEnumElement>
     )
 }
 
 export const APIEnumField: React.FunctionComponent<{ name: string; overrides?: Partial<BaseModel> }> = props => {
-    const { name, overrides } = props
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(name)
     if (!model) return <MissingModelWarning name={name} kind={Kind.EnumMember} />
 
     return (
-        <APIEnumFieldElement {...model} {...overrides}>
+        <APIEnumFieldElement {...model} {...overrides} {...rest}>
             {props.children}
         </APIEnumFieldElement>
     )

--- a/components/documentation/APIFunction.tsx
+++ b/components/documentation/APIFunction.tsx
@@ -9,12 +9,13 @@ import { Grid } from "components/layout/Grid"
 import { Permalink } from "../layout/Permalink"
 import { APIParam, APIParams } from "./APIParams"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntityExample, APIEntity } from "components/documentation/types"
 
 /**
  * Displays API information about a particular function.
  * @param props - A MethodModel object.
  */
-export const APIFunctionElement: React.FunctionComponent<MethodModel> = props => {
+export const APIFunctionElement: React.FunctionComponent<APIEntityExample<MethodModel>> = props => {
     const signatures = [props].concat(props.overloads).map(method => (
         <h3 key={method.id}>
             <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} skipnav />
@@ -24,7 +25,7 @@ export const APIFunctionElement: React.FunctionComponent<MethodModel> = props =>
 
     const parameters = props.parameters.map(param => (
         <APIParam key={param.id} name={param.name} type={param.type}>
-            <APIOverviewElement className="description" {...param} fallback={<em>None</em>} />
+            <APIOverviewElement className="description" {...param} />
         </APIParam>
     ))
     if (props.returnType !== "void" || props.returnMarkup) {
@@ -34,16 +35,11 @@ export const APIFunctionElement: React.FunctionComponent<MethodModel> = props =>
             </APIParam>
         )
     }
-    const overviewFallback = (
-        <p>
-            <em>Undocumented</em>
-        </p>
-    )
     return (
         <Grid className={apiClassName("function", props, React.Children.toArray(props.children))}>
             {signatures}
             <DeprecatedNotice {...props} />
-            <APIOverviewElement {...props} fallback={overviewFallback} />
+            <APIOverviewElement {...props} />
             {props.children}
             {parameters.length ? <APIParams>{parameters}</APIParams> : null}
         </Grid>
@@ -61,18 +57,14 @@ export const APIFunctionElement: React.FunctionComponent<MethodModel> = props =>
  * @param props.name - The name of the method to display.
  * @param props.overrides - An object containing properties of MethodModel to override.
  */
-export const APIFunction: React.FunctionComponent<{
-    name: string
-    overloadIndex?: number
-    overrides?: Partial<MethodModel>
-}> = props => {
-    const { name, overrides } = props
+export const APIFunction: React.FunctionComponent<APIEntity<MethodModel> & { overloadIndex?: number }> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(name, Kind.Function)
     if (!model) return <MissingModelWarning name={name} kind={Kind.Function} />
 
     return (
-        <APIFunctionElement {...model} {...overrides}>
+        <APIFunctionElement {...model} {...overrides} {...rest}>
             {props.children}
         </APIFunctionElement>
     )

--- a/components/documentation/APIInterface.tsx
+++ b/components/documentation/APIInterface.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { APIEntity, APIEntityExample } from "./types"
 import { InterfaceModel, Kind } from "../../api"
 import { FramerAPIContext } from "../contexts/FramerAPIContext"
 import { APIPropertyElement } from "./APIProperty"
@@ -17,7 +18,7 @@ import { apiClassName, permalinkId } from "./helpers"
  * Only renders the documentation specific to the interface. Methods and
  * properties should be provided as children.
  */
-export const APIInterfaceElement: React.FunctionComponent<InterfaceModel & {skipnav?: boolean}> = props => {
+export const APIInterfaceElement: React.FunctionComponent<APIEntityExample<InterfaceModel>> = props => {
     const children = React.Children.toArray(props.children)
     const methods = children.filter(child => React.isValidElement(child) && child.type === APIMethodElement)
     const properties = children.filter(child => React.isValidElement(child) && child.type === APIPropertyElement)
@@ -51,8 +52,8 @@ export const APIInterfaceElement: React.FunctionComponent<InterfaceModel & {skip
  * @param props.overrides - Object containing properties from InterfaceModel to override.
  * @param props.skipnav - If true will hide the item from the navigation
  */
-export const APIInterface: React.FunctionComponent<{ name: string; overrides?: Partial<InterfaceModel>; skipnav?: boolean }> = props => {
-    const { name, overrides } = props
+export const APIInterface: React.FunctionComponent<APIEntity<InterfaceModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(name, Kind.Interface)
     if (!model) return <MissingModelWarning name={props.name} kind={Kind.Interface} />
@@ -60,7 +61,7 @@ export const APIInterface: React.FunctionComponent<{ name: string; overrides?: P
     const methods = model.methods.map(method => <APIMethodElement key={method.id} {...method} />)
     const properties = model.properties.map(property => <APIPropertyElement key={property.id} {...property} />)
     return (
-        <APIInterfaceElement {...model} {...overrides} skipnav={props.skipnav}>
+        <APIInterfaceElement {...model} {...overrides} {...rest}>
             {props.children}
             {properties}
             {methods}
@@ -72,13 +73,8 @@ export const APIInterface: React.FunctionComponent<{ name: string; overrides?: P
  * Renders the documentation for an interface merged with the
  * methods/properties from any additional interfaces provided via `extras`
  */
-export const APIMergedInterface: React.FunctionComponent<{
-    name: string
-    extras?: string[]
-    overrides?: Partial<InterfaceModel>
-    skipnav?: boolean
-}> = props => {
-    const { extras = [], overrides } = props
+export const APIMergedInterface: React.FunctionComponent<APIEntity<InterfaceModel> & { extras?: string[] }> = props => {
+    const { extras = [], overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(props.name, Kind.Interface)
     if (!model) return <MissingModelWarning name={props.name} kind={Kind.Interface} />
@@ -91,7 +87,7 @@ export const APIMergedInterface: React.FunctionComponent<{
     }, [])
 
     return (
-        <APIInterfaceElement {...model} {...overrides} skipnav={props.skipnav}>
+        <APIInterfaceElement {...model} {...overrides} {...rest}>
             {props.children}
             {members}
         </APIInterfaceElement>

--- a/components/documentation/APIMethod.tsx
+++ b/components/documentation/APIMethod.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { MethodModel, Kind, ReleaseTag } from "../../api"
+import { MethodModel, Kind } from "../../api"
 import { FramerAPIContext } from "../contexts/FramerAPIContext"
 import { APIOverviewElement } from "./APIOverview"
 import { MissingModelWarning } from "./MissingModelWarning"
@@ -10,12 +10,13 @@ import { Permalink } from "../layout/Permalink"
 import { APIParam, APIParams } from "./APIParams"
 import { Signature } from "./Signature"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntityExample, APIEntity } from "./types"
 
 /**
  * Renders the documentation for a single method.
  * @param props - The MethodModel to render
  */
-export const APIMethodElement: React.FunctionComponent<MethodModel> = props => {
+export const APIMethodElement: React.FunctionComponent<APIEntityExample<MethodModel>> = props => {
     const signatures = [props].concat(props.overloads).map(method => (
         <h3 key={method.id}>
             <Permalink id={permalinkId(props)} name={props.name + "()"} modelId={props.id} skipnav />
@@ -25,7 +26,7 @@ export const APIMethodElement: React.FunctionComponent<MethodModel> = props => {
     ))
     const parameters = props.parameters.map(param => (
         <APIParam key={param.id} name={param.name} type={param.type}>
-            <APIOverviewElement className="description" {...param} fallback={<em>None</em>} />
+            <APIOverviewElement className="description" {...param} />
         </APIParam>
     ))
     if (props.returnType !== "void" || props.returnMarkup) {
@@ -40,14 +41,7 @@ export const APIMethodElement: React.FunctionComponent<MethodModel> = props => {
         <Grid className={apiClassName("method", props, React.Children.toArray(props.children))}>
             {signatures}
             <DeprecatedNotice {...props} />
-            <APIOverviewElement
-                {...props}
-                fallback={
-                    <p>
-                        <em>Undocumented</em>
-                    </p>
-                }
-            />
+            <APIOverviewElement {...props} />
             {props.children}
             {parameters.length ? <APIParams>{parameters}</APIParams> : null}
         </Grid>
@@ -61,18 +55,15 @@ export const APIMethodElement: React.FunctionComponent<MethodModel> = props => {
  * @param props.name - The name of the method to display.
  * @param props.overrides - An optional object of properties in MethodModel to override.
  */
-export const APIMethod: React.FunctionComponent<{
-    name: string
-    overrides?: Partial<MethodModel>
-}> = props => {
-    const { name, overrides } = props
+export const APIMethod: React.FunctionComponent<APIEntity<MethodModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
 
     const model = api.resolve(name, Kind.Method)
     if (!model) return <MissingModelWarning name={name} kind={Kind.Method} />
 
     return (
-        <APIMethodElement {...model} {...overrides}>
+        <APIMethodElement {...model} {...overrides} {...rest}>
             {props.children}
         </APIMethodElement>
     )

--- a/components/documentation/APINamespace.tsx
+++ b/components/documentation/APINamespace.tsx
@@ -15,6 +15,7 @@ import { NamespaceModel, Kind } from "../../api"
 import { Permalink } from "../layout/Permalink"
 import { ReleaseBadge } from "./ReleaseBadge"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntity, APIEntityExample } from "./types"
 
 /**
  * Renders documentation for a TypeScript namespace. This is usually a
@@ -24,7 +25,7 @@ import { apiClassName, permalinkId } from "./helpers"
  * Only renders the high level documentation for the namespace if available,
  * module members such as functions and variables should be provided as children.
  */
-export const APINamespaceElement: React.FunctionComponent<NamespaceModel & {skipnav?: boolean}> = props => {
+export const APINamespaceElement: React.FunctionComponent<APIEntityExample<NamespaceModel>> = props => {
     const children = React.Children.toArray(props.children)
     const members = children.filter(child => React.isValidElement(child) && child.type === NamespaceChildren)
     const rest = children.filter(child => !React.isValidElement(child) || child.type !== NamespaceChildren)
@@ -60,13 +61,14 @@ export const APINamespaceElement: React.FunctionComponent<NamespaceModel & {skip
  *
  * @param props.skipnav - If true will hide the item from the navigation
  */
-export const APINamespace: React.FunctionComponent<{ name: string; overrides?: Partial<NamespaceModel>; skipnav?: boolean }> = props => {
+export const APINamespace: React.FunctionComponent<APIEntity<NamespaceModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
-    const model = api.resolve(props.name, Kind.Namespace)
-    if (!model) return <MissingModelWarning name={props.name} kind={Kind.Namespace} />
+    const model = api.resolve(name, Kind.Namespace)
+    if (!model) return <MissingModelWarning name={name} kind={Kind.Namespace} />
 
     return (
-        <APINamespaceElement {...model} {...props.overrides} skipnav={props.skipnav}>
+        <APINamespaceElement {...model} {...overrides} {...rest}>
             {props.children}
             <NamespaceChildren {...model} />
         </APINamespaceElement>

--- a/components/documentation/APIOverview.tsx
+++ b/components/documentation/APIOverview.tsx
@@ -1,10 +1,23 @@
+import escape from "lodash.escape"
 import * as React from "react"
 import { FramerAPIContext } from "../contexts/FramerAPIContext"
 import { isProduction } from "../utils/env"
 
+export type WithHighlight = { highlight?: string }
+
 /**
  * Renders the TSDoc documentation for a particular object. Will include both
- * the `@summary` and `@remarks` sections if available.
+ * the `@summary` and `@remarks` sections if available. A `highlight` prop
+ * can be provided to highlight lines in each code snippet, this will target
+ * the first line, or an array can be passed to highlight multiple blocks.
+ *
+ * ```
+ * // highlight lines one to four in the first block
+ * <APIOverviewElement remarksMarkup={...} highlight="1-4" />
+ *
+ * // highlight lines 1 to 4 in the first block, and 8 & 11 in the third.
+ * <APIOverviewElement remarksMarkup={...} highlight={["1-4", "", "8,11"]} />
+ * ```
  */
 export const APIOverviewElement: React.FunctionComponent<{
     id?: string
@@ -12,8 +25,8 @@ export const APIOverviewElement: React.FunctionComponent<{
     remarksMarkup?: string | null
     prototypeMarkup?: string | null
     productionMarkup?: string | null
-    fallback?: React.ReactNode
     className?: string
+    highlight?: string | string[]
 }> = props => {
     const isProd = isProduction()
     const api = React.useContext(FramerAPIContext)
@@ -32,8 +45,13 @@ export const APIOverviewElement: React.FunctionComponent<{
     // Hackily resolve any inline references in the markup:
     markup = markup.replace(LinkRefRegex, (match, id: string) => {
         const model = api.resolve(id)
-        return match.replace(id, model ? model.id : id)
+        return match.replace(id, model ? escape(model.id) : id)
     })
+
+    // Insert highlight string if provided:
+    if (props.highlight) {
+        markup = insertHighlight(markup, props.highlight)
+    }
 
     return (
         <div
@@ -49,9 +67,12 @@ export const APIOverviewElement: React.FunctionComponent<{
  * the `@summary` and `@remarks` sections if available.
  * @param props.name - The name of the API entity.
  */
-export const APIOverview: React.FunctionComponent<{ name: string }> = ({ name }) => {
+export const APIOverview: React.FunctionComponent<{ name: string; highlight: string | string[] }> = ({
+    name,
+    highlight,
+}) => {
     const api = React.useContext(FramerAPIContext)
-    return <APIOverviewElement {...api.resolve(name)} />
+    return <APIOverviewElement {...api.resolve(name)} highlight={highlight} />
 }
 
 /**
@@ -59,3 +80,17 @@ export const APIOverview: React.FunctionComponent<{ name: string }> = ({ name })
  * value. Used for find/replace of @link tokens.
  */
 const LinkRefRegex = /data-link-ref="([^"]+)"/g
+
+/**
+ * Inserts a metastring="highlight()" attribute into codeblocks or do nothing
+ * if no range was found for the codeblock.
+ */
+function insertHighlight(html: string, value: string | string[]): string {
+    let index = 0
+    const values = Array.isArray(value) ? value : [value]
+    return html.replace(/data-lang=/gi, match => {
+        const range = values[index++] || null
+        return range ? `metastring="highlight(${escape(range)})" ${match}` : match
+    })
+}
+

--- a/components/documentation/APIProperty.tsx
+++ b/components/documentation/APIProperty.tsx
@@ -9,8 +9,9 @@ import { Grid } from "components/layout/Grid"
 import { Permalink } from "../layout/Permalink"
 import { Signature } from "./Signature"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntity, APIEntityExample } from "./types"
 
-export const APIPropertyElement: React.FunctionComponent<PropertyModel> = props => {
+export const APIPropertyElement: React.FunctionComponent<APIEntityExample<PropertyModel>> = props => {
     return (
         <Grid className={apiClassName("property", props, React.Children.toArray(props.children))}>
             <h3>
@@ -19,14 +20,7 @@ export const APIPropertyElement: React.FunctionComponent<PropertyModel> = props 
                 <ReleaseBadge {...props} />
             </h3>
             <DeprecatedNotice {...props} />
-            <APIOverviewElement
-                {...props}
-                fallback={
-                    <p>
-                        <em>Undocumented</em>
-                    </p>
-                }
-            />
+            <APIOverviewElement {...props} />
             {props.children}
         </Grid>
     )
@@ -38,18 +32,15 @@ export const APIPropertyElement: React.FunctionComponent<PropertyModel> = props 
  * @param props.name The name of the property including classname and namespaces.
  * @param props.overrides An object containing PropertyModel properties to override
  */
-export const APIProperty: React.FunctionComponent<{
-    name: string
-    overrides?: Partial<PropertyModel>
-}> = props => {
+export const APIProperty: React.FunctionComponent<APIEntity<PropertyModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
 
-    const model = api.resolve(props.name, Kind.Property)
-
-    if (!model) return <MissingModelWarning name={props.name} kind={Kind.Property} />
+    const model = api.resolve(name, Kind.Property)
+    if (!model) return <MissingModelWarning name={name} kind={Kind.Property} />
 
     return (
-        <APIPropertyElement {...model} {...props.overrides}>
+        <APIPropertyElement {...model} {...overrides} {...rest}>
             {props.children}
         </APIPropertyElement>
     )

--- a/components/documentation/APIReactComponent.tsx
+++ b/components/documentation/APIReactComponent.tsx
@@ -9,13 +9,14 @@ import { DeprecatedNotice } from "./DeprecatedNotice"
 import { Grid } from "../layout/Grid"
 import { Permalink } from "../layout/Permalink"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntityExample, APIEntity } from "./types"
 
 /**
  * Renders React specific documentation for the TypeScript class provided.
  *
  * Only renders the documentation specific to the class. Methods and properties should be provided as children.
  */
-export const APIReactComponentElement: React.FunctionComponent<ClassModel> = props => {
+export const APIReactComponentElement: React.FunctionComponent<APIEntityExample<ClassModel>> = props => {
     const children = React.Children.toArray(props.children)
     const methods = children.filter(child => React.isValidElement(child) && child.type === APIMethodElement)
 
@@ -43,15 +44,16 @@ export const APIReactComponentElement: React.FunctionComponent<ClassModel> = pro
  * @param props.name The name of the React component
  * @param props.overrides Optional object of properties in ClassModel to override
  */
-export const APIReactComponent: React.FunctionComponent<{ name: string; overrides?: Partial<ClassModel> }> = props => {
+export const APIReactComponent: React.FunctionComponent<APIEntity<ClassModel>> = props => {
+    const { name, overrides, ...rest } = props
     const api = React.useContext(FramerAPIContext)
 
-    const model = api.resolve(props.name, Kind.Class)
-    if (!model) return <MissingModelWarning name={props.name} kind={Kind.Class} />
+    const model = api.resolve(name, Kind.Class)
+    if (!model) return <MissingModelWarning name={name} kind={Kind.Class} />
 
     const methods = model.methods.map(method => <APIMethodElement key={method.id} {...method} />)
     return (
-        <APIReactComponentElement {...model} {...props.overrides}>
+        <APIReactComponentElement {...model} {...overrides} {...rest}>
             {props.children}
             {methods}
         </APIReactComponentElement>

--- a/components/documentation/APISummary.tsx
+++ b/components/documentation/APISummary.tsx
@@ -6,7 +6,9 @@ import { MissingModelWarning } from "./MissingModelWarning"
  * Renders the TSDoc summary provided. `summaryMarkup` is just static HTML. To
  * display the full documentation use the `<APIOverviewElement>`.
  */
-export const APISummaryElement: React.FunctionComponent<{ summaryMarkup: string | null | undefined }> = props => {
+export const APISummaryElement: React.FunctionComponent<{
+    summaryMarkup: string | null | undefined
+}> = props => {
     if (!props.summaryMarkup) return null
     return <APIOverviewElement {...props} />
 }

--- a/components/documentation/APIVariable.tsx
+++ b/components/documentation/APIVariable.tsx
@@ -8,8 +8,9 @@ import { DeprecatedNotice } from "./DeprecatedNotice"
 import { Grid } from "components/layout/Grid"
 import { Permalink } from "../layout/Permalink"
 import { apiClassName, permalinkId } from "./helpers"
+import { APIEntity, APIEntityExample } from "./types"
 
-export const APIVariableElement: React.FunctionComponent<PropertyModel> = props => {
+export const APIVariableElement: React.FunctionComponent<APIEntityExample<PropertyModel>> = props => {
     return (
         <Grid className={apiClassName("variable", props, React.Children.toArray(props.children))}>
             <h3>
@@ -18,24 +19,13 @@ export const APIVariableElement: React.FunctionComponent<PropertyModel> = props 
                 <ReleaseBadge {...props} />
             </h3>
             <DeprecatedNotice {...props} />
-            <APIOverviewElement
-                {...props}
-                fallback={
-                    <p>
-                        <em>Undocumented</em>
-                    </p>
-                }
-            />
+            <APIOverviewElement {...props} />
             {props.children}
         </Grid>
     )
 }
 
-export const APIVariable: React.FunctionComponent<{
-    name: string
-    isStatic?: boolean
-    overrides?: Partial<PropertyModel>
-}> = props => {
+export const APIVariable: React.FunctionComponent<APIEntity<PropertyModel>> = props => {
     const api = React.useContext(FramerAPIContext)
     const model = api.resolve(props.name, Kind.Variable)
     if (!model) return <MissingModelWarning name={props.name} kind={Kind.Variable} />

--- a/components/documentation/helpers.ts
+++ b/components/documentation/helpers.ts
@@ -1,4 +1,4 @@
-import * as className from "classnames"
+import className from "classnames"
 import { AnyModel, BaseModel } from "../../api"
 
 export function isHeaderEmpty(model: AnyModel, children: any[] = []): boolean {

--- a/components/documentation/types.ts
+++ b/components/documentation/types.ts
@@ -1,0 +1,6 @@
+import { WithSkipNav } from "../layout/Permalink"
+import { WithHighlight } from "./APIOverview"
+
+export type APIEntity<Model> = { name: string; overrides?: Partial<Model> } & WithSkipNav & WithHighlight
+
+export type APIEntityExample<Model> = Model & WithSkipNav & WithHighlight

--- a/components/layout/Permalink.tsx
+++ b/components/layout/Permalink.tsx
@@ -3,6 +3,8 @@ import * as ReactDOM from "react-dom"
 import styled from "styled-components"
 import { usePath, Dynamic } from "monobase"
 
+export type WithSkipNav = { skipnav?: boolean }
+
 const Info = styled.div`
     position: fixed;
     top: 10px;
@@ -136,7 +138,7 @@ const PermalinkSpan = styled.span`
     }
 `
 
-export const Permalink: React.FunctionComponent<{ id: string; name: string; modelId?: string, skipnav?: boolean }> = ({
+export const Permalink: React.FunctionComponent<{ id: string; name: string; modelId?: string; skipnav?: boolean }> = ({
     id,
     name,
     modelId,
@@ -162,8 +164,17 @@ export const Permalink: React.FunctionComponent<{ id: string; name: string; mode
  * Puts a linkable anchor on the page, see <RefAnchor />. The `modelId` should
  * be the API model identifier, used to link up the <Ref> component.
  */
-export const PermalinkAnchor: React.FunctionComponent<{ id: string, modelId?: string }> = ({ id, modelId }) => {
+export const PermalinkAnchor: React.FunctionComponent<{ id: string; modelId?: string }> = ({ id, modelId }) => {
     // Offset the permalink from its position in the DOM to give some breathing room.
     const style: React.CSSProperties = { position: "absolute", top: -60, display: "block" }
-    return <span id={id} data-permalink-id={id} data-permalink-path={`${usePath()}#${id}`} data-permalink-ref={modelId} aria-hidden style={style} />
+    return (
+        <span
+            id={id}
+            data-permalink-id={id}
+            data-permalink-path={`${usePath()}#${id}`}
+            data-permalink-ref={modelId}
+            aria-hidden
+            style={style}
+        />
+    )
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.6",
     "@microsoft/api-extractor-model": "^7.1.1",
     "@microsoft/tsdoc": "^0.12.9",
     "@types/chalk": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer": "^1.0.8",
     "framer-motion": "^0.18.6",
     "jest": "^24.3.1",
+    "lodash.escape": "^4.0.1",
     "monobase": "^3.2.2",
     "prettier": "^1.16.4",
     "prismjs": "^1.15.0",

--- a/pages/render-target.mdx
+++ b/pages/render-target.mdx
@@ -29,5 +29,5 @@ Components can use the `RenderTarget.current()` method to check for the environm
 
 ## Functions
 
-<APIFunction name="RenderTarget.current()" />
-<APIFunction name="RenderTarget.hasRestrictions()" />
+<APIFunction name="RenderTarget.current()" highlight="2-4" />
+<APIFunction name="RenderTarget.hasRestrictions()" highlight="2-4" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "baseUrl": ".",
+        "downlevelIteration": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
         "lib": ["es2015", "es2017.object", "dom"],
         "module": "commonjs",
-        "jsx": "react",
-        "baseUrl": ".",
-        "resolveJsonModule": true,
         "outDir": "build",
-        "downlevelIteration": true,
+        "resolveJsonModule": true,
         "strict": true,
-        "forceConsistentCasingInFileNames": true
+        "target": "es5"
     },
     "exclude": ["node_modules/**/*", "build/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,8 +981,9 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
 
 "@types/lodash.escape@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash.escape/-/lodash.escape-4.0.5.tgz#4af0fc2e9293abf906c81dce113f9d0fa206e753"
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.escape/-/lodash.escape-4.0.6.tgz#71730c1a27bb5ac7f98f88d5e858fa4ad2df1106"
+  integrity sha512-/CI97B3wf1R4oD4yotsGoX/5bobL/RC8olTQ16iunzdjufcdD8GyIvNDatg1IfzVKaFBZmxuY0+WQDpdaQHLzg==
   dependencies:
     "@types/lodash" "*"
 
@@ -5062,6 +5063,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,7 @@
   version "1.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-1.0.0-alpha.6.tgz#2ae87d75c1f2cf6d4a79d863bfd1ce441dd34fd5"
 
-"@microsoft/api-extractor-model@7.1.1", "@microsoft/api-extractor-model@^7.1.1":
+"@microsoft/api-extractor-model@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.1.1.tgz#17aa30fe641db7efbcfb779f4a87b8461d6a2322"
   integrity sha512-RiQJA8JpBbRxqUfro8SxZGLjeCFH8HUUJvD5VTUrDrgdt13omx7d0bsGN0lf+AT63yF+RX4R2+Jd2b0SaAO/sQ==
@@ -802,21 +802,6 @@
     "@microsoft/node-core-library" "3.13.0"
     "@microsoft/tsdoc" "0.12.9"
     "@types/node" "8.5.8"
-
-"@microsoft/api-extractor@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.1.6.tgz#1a1210acb0a3d01fef6e6f664d41961fc9705634"
-  integrity sha512-0oXmPnJyc7OXA/+TKHUPW/HWG9qLhjoz5uAvKoI/9csnH5a0mzO+5k1LitPhY/O0rWPz5lghX16JnSm6G4mJ2Q==
-  dependencies:
-    "@microsoft/api-extractor-model" "7.1.1"
-    "@microsoft/node-core-library" "3.13.0"
-    "@microsoft/ts-command-line" "4.2.5"
-    "@microsoft/tsdoc" "0.12.9"
-    colors "~1.2.1"
-    lodash "~4.17.5"
-    resolve "1.8.1"
-    source-map "~0.6.1"
-    typescript "~3.4.3"
 
 "@microsoft/node-core-library@3.13.0":
   version "3.13.0"
@@ -831,16 +816,6 @@
     fs-extra "~7.0.1"
     jju "~1.4.0"
     z-schema "~3.18.3"
-
-"@microsoft/ts-command-line@4.2.5":
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.2.5.tgz#ef5060c841e2e604c1e51c68f1b890a9b75ec6ff"
-  integrity sha512-QyTfbfpx6o+1cnjx5GubqKSRMDxBBMXABSa8wmqRa/A1K99FEBZfLIO6GmaY0s7rNYEchfR1VcVS/hV2VW+6hw==
-  dependencies:
-    "@types/argparse" "1.0.33"
-    "@types/node" "8.5.8"
-    argparse "~1.0.9"
-    colors "~1.2.1"
 
 "@microsoft/tsdoc@0.12.9", "@microsoft/tsdoc@^0.12.9":
   version "0.12.9"
@@ -869,11 +844,6 @@
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
   dependencies:
     defer-to-connect "^1.0.1"
-
-"@types/argparse@1.0.33":
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
-  integrity sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==
 
 "@types/babel__core@^7.1.0":
   version "7.1.0"
@@ -1421,7 +1391,7 @@ arg@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
 
-argparse@^1.0.7, argparse@~1.0.9:
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -5089,7 +5059,7 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10, lodash@~4.17.5:
+lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6702,13 +6672,6 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
-  dependencies:
-    path-parse "^1.0.5"
-
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
@@ -7637,11 +7600,6 @@ typedarray@^0.0.6:
 typescript@^3.1.6:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
-
-typescript@~3.4.3:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This allows highlighting of specific rows within a component example in the same way we do with fenced code blocks in MDX files.

In mdx we would do the following to highlight the middle row:

    ```jsx highlight(2)
    function MyComponent() {
      return <Frame size={“100%”} />
    }
    ``` 

To do this for an API component we would do the following:

    <APIFunction name=“Color.toRGBString()” highlight=“2” />

Should the API @remarks block contain multiple code blocks we’ll need to pass an array instead of a single string.

     <APIFunction name=“Color.toRGBString()” highlight={[“”, “2”, “1-3"]} />

_NOTE: A “falsy” value will omit the highlight block altogether for that code block_