### PR TITLE
Add changelog page to API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 components/framer.data.ts
 node_modules
+pages/changelog.mdx

--- a/components/Changelog.tsx
+++ b/components/Changelog.tsx
@@ -1,0 +1,11 @@
+import * as React from "react"
+import { Page } from "./Template"
+import { MarkdownStyles } from "./layout/Markdown"
+
+export const Changelog: React.FC = ({ children }) => {
+    return (
+        <Page title="Changelog">
+            <MarkdownStyles>{children}</MarkdownStyles>
+        </Page>
+    )
+}

--- a/components/Template.tsx
+++ b/components/Template.tsx
@@ -107,6 +107,7 @@ export const Template: React.FunctionComponent<{ title?: string }> = ({ title, c
     return (
         <Page title={title}>
             <Markdown>{children}</Markdown>
+            <Codebar className="codebar" />
         </Page>
     )
 }
@@ -143,7 +144,6 @@ export const Page: React.FunctionComponent<{ title?: string; showEdit?: boolean 
                 ) : null}
 
                 {children}
-                <Codebar className="codebar" />
             </Main>
             {/* The Development component adds auto reloading */}
             <Development />
@@ -156,7 +156,7 @@ export const Page: React.FunctionComponent<{ title?: string; showEdit?: boolean 
             <FramerAPIDefaultProvider>
                 <head>
                     <meta charSet="utf-8" />
-                    <title>Framer API{title ? <> {title}</> : null}</title>
+                    <title>{`Framer API${title ? ` ${title}` : ""}`}</title>
                     <link rel="stylesheet" href={urlFor("/static/styles/fonts.css")} />
                     <link rel="stylesheet" href={urlFor("/static/styles/highlight.css")} />
                     <link rel="stylesheet" href={urlFor("/static/styles/reset.css")} />

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { Page } from "../components/Template"
+import { Codebar } from "../components/layout/Codebar"
 import { MarkdownStyles, InlineButton, Grid, Center } from "components"
 
 export default function render() {
@@ -33,6 +34,7 @@ export default function render() {
                     </svg>
                 </Center>
             </Grid>
+            <Codebar />
         </Page>
     )
 }


### PR DESCRIPTION
This takes the CHANGELOG.md file from the current “framer” release in node_modules and embeds it under the framer.com/api/changelog url. The pages/changelog.mdx is generated for each call to `make build` or `make serve`.