### PR TITLE
Migrate code highlight feature to use “Props” API

### DIFF
--- a/components/documentation/APIOverview.tsx
+++ b/components/documentation/APIOverview.tsx
@@ -90,7 +90,7 @@ function insertHighlight(html: string, value: string | string[]): string {
     const values = Array.isArray(value) ? value : [value]
     return html.replace(/data-lang=/gi, match => {
         const range = values[index++] || null
-        return range ? `metastring="highlight(${escape(range)})" ${match}` : match
+        return range ? `highlight="\"${escape(range)})\"" ${match}` : match
     })
 }
 

--- a/components/documentation/APIOverview.tsx
+++ b/components/documentation/APIOverview.tsx
@@ -90,7 +90,7 @@ function insertHighlight(html: string, value: string | string[]): string {
     const values = Array.isArray(value) ? value : [value]
     return html.replace(/data-lang=/gi, match => {
         const range = values[index++] || null
-        return range ? `highlight="\"${escape(range)})\"" ${match}` : match
+        return range ? `highlight="${escape(range)})" ${match}` : match
     })
 }
 

--- a/components/highlighter.ts
+++ b/components/highlighter.ts
@@ -4,7 +4,7 @@ import "prismjs/components/prism-jsx"
 import "prismjs/components/prism-tsx"
 import "prismjs/components/prism-typescript"
 
-const HighlightLineRegex = /highlight\(([^)]+)\)/i
+const HighlightLineRegex = /"([^)]+)"/i
 
 const isNumber = (num: number) => !Number.isNaN(num)
 
@@ -13,7 +13,7 @@ Prism.hooks.add("before-insert", env => {
     const source = env.highlightedCode
     if (!source || !el || el.classList.contains("highlight-line")) return
 
-    const metastring = el.getAttribute("metastring")
+    const metastring = el.getAttribute("highlight")
     const match = metastring && HighlightLineRegex.exec(metastring)
     if (!match) return
 

--- a/components/highlighter.ts
+++ b/components/highlighter.ts
@@ -4,8 +4,6 @@ import "prismjs/components/prism-jsx"
 import "prismjs/components/prism-tsx"
 import "prismjs/components/prism-typescript"
 
-const HighlightLineRegex = /"([^)]+)"/i
-
 const isNumber = (num: number) => !Number.isNaN(num)
 
 Prism.hooks.add("before-insert", env => {
@@ -13,12 +11,20 @@ Prism.hooks.add("before-insert", env => {
     const source = env.highlightedCode
     if (!source || !el || el.classList.contains("highlight-line")) return
 
-    const metastring = el.getAttribute("highlight")
-    const match = metastring && HighlightLineRegex.exec(metastring)
-    if (!match) return
+    const highlight = el.getAttribute("highlight")
+    if (!highlight) return
+
+    // If the fenced code block has a metastring attribute then the highlight
+    // prop likely contained spaces and may be malformed.
+    const metastring = el.getAttribute("metastring") || ""
+    if (metastring.length > 0) {
+        console.warn(
+            `Found "metastring" attribute "${metastring}" on a code block, ensure there are no spaces in your highlight block: "${highlight}"`
+        )
+    }
 
     // Format is 1-3,6-8
-    const ranges = match[1].split(",").map(range => {
+    const ranges = highlight.split(",").map(range => {
         const parsed = range
             .trim()
             .split("-")

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -25,9 +25,9 @@ images and other media from code.
 
 ## Functions
 
-<div class="framer-api framer-function">
+<div className="framer-api framer-function">
 
-<H3 id="url"><code class="language-typescript">url(path: string): string</code></H3>
+<H3 id="url"><code className="language-typescript">url(path: string): string</code></H3>
 
 </div>
 <div>

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -49,7 +49,7 @@ the component is being used (for example, in the Canvas, Preview or Export).
 <br/>
 </div>
 
-```jsx highlight(3,7)
+```jsx highlight="3,7"
 import * as React from "react"
 import { Frame } from "framer"
 import { url } from "framer/resource"
@@ -66,7 +66,7 @@ project is opened so use it directly within your
 components and avoid storing the result or using it as a
 value in a custom property control.
 
-```jsx highlight(1-2,5)
+```jsx highlight="1-2,5"
 // GOOD: Use a relative path. Call url() within component.
 const image = "./code/test.png"
 
@@ -75,7 +75,7 @@ export function MyComponent() {
 }
 ```
 
-```jsx highlight(1-2,5)
+```jsx highlight="1-2,5"
 // BAD: Avoid this. The returned url may change over time.
 const image = url("./code/test.png")
 

--- a/pages/assets.mdx
+++ b/pages/assets.mdx
@@ -49,7 +49,7 @@ the component is being used (for example, in the Canvas, Preview or Export).
 <br/>
 </div>
 
-```jsx highlight="3,7"
+```jsx highlight=3,7
 import * as React from "react"
 import { Frame } from "framer"
 import { url } from "framer/resource"
@@ -66,7 +66,7 @@ project is opened so use it directly within your
 components and avoid storing the result or using it as a
 value in a custom property control.
 
-```jsx highlight="1-2,5"
+```jsx highlight=1-2,5
 // GOOD: Use a relative path. Call url() within component.
 const image = "./code/test.png"
 
@@ -75,7 +75,7 @@ export function MyComponent() {
 }
 ```
 
-```jsx highlight="1-2,5"
+```jsx highlight=1-2,5
 // BAD: Avoid this. The returned url may change over time.
 const image = url("./code/test.png")
 

--- a/pages/examples.mdx
+++ b/pages/examples.mdx
@@ -26,7 +26,7 @@ The `Frame` is a basic container for layout, styling, animation and events. It�
 
 </div>
 
-```jsx highlight(6)
+```jsx highlight="6"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -53,7 +53,7 @@ It’s based on a `Frame`, which means it supports all Frame properties. In this
 
 </div>
 
-```jsx highlight(6-10)
+```jsx highlight="6-10"
 import * as React from "react"
 import { Frame, Stack } from "framer"
 
@@ -85,7 +85,7 @@ With the `transition` property, we can customize the animation options, like set
 
 </div>
 
-```jsx highlight(6-9)
+```jsx highlight="6-9"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -116,7 +116,7 @@ Here, we’re setting the `loop` property to `Infinity`, and the `ease` to `line
 
 </div>
 
-```jsx highlight(6-13)
+```jsx highlight="6-13"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -150,7 +150,7 @@ Here, we’re cycling between 2 sets of properties on every tap.
 
 </div>
 
-```jsx highlight(2, 5-8, 10)
+```jsx highlight="2, 5-8, 10"
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 
@@ -179,7 +179,7 @@ Color strings can also be animated by using the `background` property. In this e
 
 </div>
 
-```jsx highlight(6-13)
+```jsx highlight="6-13"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -212,7 +212,7 @@ Next to single values, you can also animate arrays of values within the `animate
 
 </div>
 
-```jsx highlight(6-13)
+```jsx highlight="6-13"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -249,7 +249,7 @@ Finally, we’ll pass along `rotate` to the `animate` property, and the `toggleR
 
 </div>
 
-```jsx highlight(2, 6-7, 9)
+```jsx highlight="2, 6-7, 9"
 import * as React from "react"
 import { useState } from "react"
 import { Frame } from "framer"
@@ -278,7 +278,7 @@ We can use the `whileHover` property, and pass along a property an its value.
 
 </div>
 
-```jsx highlight(5)
+```jsx highlight="5"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -293,7 +293,7 @@ export function MyComponent() {
 
 You can easily make any `Frame` draggable with the `drag` property. It can be set to control the drag axis using `"x"` or `"y"`. It can also be dragged in any direction by setting it to `true`.
 
-```jsx highlight(5)
+```jsx highlight="5"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -320,7 +320,7 @@ The values are measured relatively to the current object, so if you wanted to al
 
 </div>
 
-```jsx highlight(6-14)
+```jsx highlight="6-14"
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -354,7 +354,7 @@ For scrolling, you can wrap Frames in a `Scroll` component, to make them automat
 
 </div>
 
-```jsx highlight(2, 6-10)
+```jsx highlight="2, 6-10"
 import * as React from "react"
 import { Frame, Scroll } from "framer"
 
@@ -384,7 +384,7 @@ For paging, you can wrap Frames in a `Page` component to make them swipeable. Op
 
 </div>
 
-```jsx highlight(2, 6-10)
+```jsx highlight="2, 6-10"
 import * as React from "react"
 import { Frame, Page } from "framer"
 
@@ -417,7 +417,7 @@ Finally, we’ll apply both properties to the `Frame`.
 
 </div>
 
-```jsx highlight(2, 5-6, 8)
+```jsx highlight="2, 5-6, 8"
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 
@@ -451,7 +451,7 @@ Finally, we’re referencing the properties using the `variants` property, and a
 
 </div>
 
-```jsx highlight(5-8, 11-15)
+```jsx highlight="5-8, 11-15"
 import * as React from "react"
 import { Frame } from "framer"
 

--- a/pages/examples.mdx
+++ b/pages/examples.mdx
@@ -26,7 +26,7 @@ The `Frame` is a basic container for layout, styling, animation and events. It�
 
 </div>
 
-```jsx highlight="6"
+```jsx highlight=6
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -53,7 +53,7 @@ It’s based on a `Frame`, which means it supports all Frame properties. In this
 
 </div>
 
-```jsx highlight="6-10"
+```jsx highlight=6-10
 import * as React from "react"
 import { Frame, Stack } from "framer"
 
@@ -85,7 +85,7 @@ With the `transition` property, we can customize the animation options, like set
 
 </div>
 
-```jsx highlight="6-9"
+```jsx highlight=6-9
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -116,7 +116,7 @@ Here, we’re setting the `loop` property to `Infinity`, and the `ease` to `line
 
 </div>
 
-```jsx highlight="6-13"
+```jsx highlight=6-13
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -150,7 +150,7 @@ Here, we’re cycling between 2 sets of properties on every tap.
 
 </div>
 
-```jsx highlight="2, 5-8, 10"
+```jsx highlight=2,5-8,10
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 
@@ -179,7 +179,7 @@ Color strings can also be animated by using the `background` property. In this e
 
 </div>
 
-```jsx highlight="6-13"
+```jsx highlight=6-13
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -212,7 +212,7 @@ Next to single values, you can also animate arrays of values within the `animate
 
 </div>
 
-```jsx highlight="6-13"
+```jsx highlight=6-13
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -249,7 +249,7 @@ Finally, we’ll pass along `rotate` to the `animate` property, and the `toggleR
 
 </div>
 
-```jsx highlight="2, 6-7, 9"
+```jsx highlight=2,6-7,9
 import * as React from "react"
 import { useState } from "react"
 import { Frame } from "framer"
@@ -278,7 +278,7 @@ We can use the `whileHover` property, and pass along a property an its value.
 
 </div>
 
-```jsx highlight="5"
+```jsx highlight=5
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -293,7 +293,7 @@ export function MyComponent() {
 
 You can easily make any `Frame` draggable with the `drag` property. It can be set to control the drag axis using `"x"` or `"y"`. It can also be dragged in any direction by setting it to `true`.
 
-```jsx highlight="5"
+```jsx highlight=5
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -320,7 +320,7 @@ The values are measured relatively to the current object, so if you wanted to al
 
 </div>
 
-```jsx highlight="6-14"
+```jsx highlight=6-14
 import * as React from "react"
 import { Frame } from "framer"
 
@@ -354,7 +354,7 @@ For scrolling, you can wrap Frames in a `Scroll` component, to make them automat
 
 </div>
 
-```jsx highlight="2, 6-10"
+```jsx highlight=2,6-10
 import * as React from "react"
 import { Frame, Scroll } from "framer"
 
@@ -384,7 +384,7 @@ For paging, you can wrap Frames in a `Page` component to make them swipeable. Op
 
 </div>
 
-```jsx highlight="2, 6-10"
+```jsx highlight=2,6-10
 import * as React from "react"
 import { Frame, Page } from "framer"
 
@@ -417,7 +417,7 @@ Finally, we’ll apply both properties to the `Frame`.
 
 </div>
 
-```jsx highlight="2, 5-6, 8"
+```jsx highlight=2,5-6,8
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 
@@ -451,7 +451,7 @@ Finally, we’re referencing the properties using the `variants` property, and a
 
 </div>
 
-```jsx highlight="5-8, 11-15"
+```jsx highlight=5-8,11-15
 import * as React from "react"
 import { Frame } from "framer"
 

--- a/pages/frame.mdx
+++ b/pages/frame.mdx
@@ -44,7 +44,7 @@ The `Frame` component is a `div` with extra options and opinionated defaults to 
 
 </div>
 
-```jsx highlight="1"
+```jsx highlight=1
 import * as React from "react"
 import { Frame } from "framer"
 

--- a/pages/frame.mdx
+++ b/pages/frame.mdx
@@ -44,7 +44,7 @@ The `Frame` component is a `div` with extra options and opinionated defaults to 
 
 </div>
 
-```jsx
+```jsx highlight="1"
 import * as React from "react"
 import { Frame } from "framer"
 

--- a/pages/motion/animate-presence.mdx
+++ b/pages/motion/animate-presence.mdx
@@ -159,7 +159,7 @@ By setting `initial={false}` on `AnimatePresence`, components present when `Anim
 
 </div>
 
-```jsx highlight="2, 5-6"
+```jsx highlight=2,5-6
 const MyComponent = ({ isVisible }) => (
   <AnimatePresence initial={false}>
     {isVisible && (

--- a/pages/motion/animate-presence.mdx
+++ b/pages/motion/animate-presence.mdx
@@ -159,7 +159,7 @@ By setting `initial={false}` on `AnimatePresence`, components present when `Anim
 
 </div>
 
-```jsx highlight(2, 5-6)
+```jsx highlight="2, 5-6"
 const MyComponent = ({ isVisible }) => (
   <AnimatePresence initial={false}>
     {isVisible && (

--- a/pages/motion/examples.mdx
+++ b/pages/motion/examples.mdx
@@ -49,7 +49,7 @@ The animation used can be configured using the `transition` prop.
   <AnimationBasicExample />
 </EmbeddedExample>
 
-```jsx highlight(4-7)
+```jsx highlight="4-7"
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -81,7 +81,7 @@ By default, each keyframe will be spaced evenly throughout the animation, but th
   <AnimationKeyframesExample />
 </EmbeddedExample>
 
-```jsx highlight(5-9)
+```jsx highlight="5-9"
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -118,7 +118,7 @@ Variants can also be dynamic functions that return different props based on data
   <AnimationVariantsExample />
 </EmbeddedExample>
 
-```jsx highlight(3-7,13-14)
+```jsx highlight="3-7,13-14"
 import { motion } from "framer-motion"
 
 const variants = {
@@ -164,7 +164,7 @@ Motion will also automatically handle the interplay of the two gestures, so if a
   <GestureAnimationShortcuts />
 </EmbeddedExample>
 
-```jsx highlight(5-6)
+```jsx highlight="5-6"
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -198,7 +198,7 @@ These constraints are elastic, and the strength of this elasticity can be config
   <GestureDrag />
 </EmbeddedExample>
 
-```jsx highlight(5-11)
+```jsx highlight="5-11"
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -235,7 +235,7 @@ By making `MotionValue`s yourself, you can create declarative chains of values t
   <MotionValueSVG />
 </EmbeddedExample>
 
-```jsx highlight(8-13)
+```jsx highlight="8-13"
 import {
   motion,
   useMotionValue,
@@ -285,7 +285,7 @@ You can use these `MotionValue`s to declaratively drive features like progress i
   <ViewportScroll />
 </EmbeddedExample>
 
-```jsx highlight(4-13)
+```jsx highlight="4-13"
 import { motion, useViewportScroll } from "framer-motion"
 
 export const CircleIndicator = () => {
@@ -321,7 +321,7 @@ By wrapping `motion` components with `AnimatePresence`, they gain the use of an 
   <AnimatePresenceExample />
 </EmbeddedExample>
 
-```jsx highlight(4,10,13)
+```jsx highlight="4,10,13"
 import { motion, AnimatePresence } from "framer-motion"
 
 export const Slideshow = ({ image }) => (
@@ -360,7 +360,7 @@ It's great for smoothly reordering lists, and becomes super-powerful when paired
   <PositionTransition />
 </EmbeddedExample>
 
-```jsx highlight(4)
+```jsx highlight="4"
 import { motion } from "framer-motion"
 
 export const List = ({ items }) =>

--- a/pages/motion/examples.mdx
+++ b/pages/motion/examples.mdx
@@ -49,7 +49,7 @@ The animation used can be configured using the `transition` prop.
   <AnimationBasicExample />
 </EmbeddedExample>
 
-```jsx highlight="4-7"
+```jsx highlight=4-7
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -81,7 +81,7 @@ By default, each keyframe will be spaced evenly throughout the animation, but th
   <AnimationKeyframesExample />
 </EmbeddedExample>
 
-```jsx highlight="5-9"
+```jsx highlight=5-9
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -118,7 +118,7 @@ Variants can also be dynamic functions that return different props based on data
   <AnimationVariantsExample />
 </EmbeddedExample>
 
-```jsx highlight="3-7,13-14"
+```jsx highlight=3-7,13-14
 import { motion } from "framer-motion"
 
 const variants = {
@@ -164,7 +164,7 @@ Motion will also automatically handle the interplay of the two gestures, so if a
   <GestureAnimationShortcuts />
 </EmbeddedExample>
 
-```jsx highlight="5-6"
+```jsx highlight=5-6
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -198,7 +198,7 @@ These constraints are elastic, and the strength of this elasticity can be config
   <GestureDrag />
 </EmbeddedExample>
 
-```jsx highlight="5-11"
+```jsx highlight=5-11
 import { motion } from "framer-motion"
 
 export const MyComponent = () => (
@@ -235,7 +235,7 @@ By making `MotionValue`s yourself, you can create declarative chains of values t
   <MotionValueSVG />
 </EmbeddedExample>
 
-```jsx highlight="8-13"
+```jsx highlight=8-13
 import {
   motion,
   useMotionValue,
@@ -285,7 +285,7 @@ You can use these `MotionValue`s to declaratively drive features like progress i
   <ViewportScroll />
 </EmbeddedExample>
 
-```jsx highlight="4-13"
+```jsx highlight=4-13
 import { motion, useViewportScroll } from "framer-motion"
 
 export const CircleIndicator = () => {
@@ -321,7 +321,7 @@ By wrapping `motion` components with `AnimatePresence`, they gain the use of an 
   <AnimatePresenceExample />
 </EmbeddedExample>
 
-```jsx highlight="4,10,13"
+```jsx highlight=4,10,13
 import { motion, AnimatePresence } from "framer-motion"
 
 export const Slideshow = ({ image }) => (
@@ -360,7 +360,7 @@ It's great for smoothly reordering lists, and becomes super-powerful when paired
   <PositionTransition />
 </EmbeddedExample>
 
-```jsx highlight="4"
+```jsx highlight=4
 import { motion } from "framer-motion"
 
 export const List = ({ items }) =>

--- a/pages/render-target.mdx
+++ b/pages/render-target.mdx
@@ -29,5 +29,5 @@ Components can use the `RenderTarget.current()` method to check for the environm
 
 ## Functions
 
-<APIFunction name="RenderTarget.current()" highlight="2-4" />
-<APIFunction name="RenderTarget.hasRestrictions()" highlight="2-4" />
+<APIFunction name="RenderTarget.current()" highlight=2-4 />
+<APIFunction name="RenderTarget.hasRestrictions()" highlight=2-4 />

--- a/pages/render-target.mdx
+++ b/pages/render-target.mdx
@@ -29,5 +29,5 @@ Components can use the `RenderTarget.current()` method to check for the environm
 
 ## Functions
 
-<APIFunction name="RenderTarget.current()" highlight=2-4 />
-<APIFunction name="RenderTarget.hasRestrictions()" highlight=2-4 />
+<APIFunction name="RenderTarget.current()" highlight="2-4" />
+<APIFunction name="RenderTarget.hasRestrictions()" highlight="2-4" />

--- a/pages/tutorial.mdx
+++ b/pages/tutorial.mdx
@@ -188,7 +188,7 @@ Your `App` component needs to know about the `Slider` component so it can be use
 
 </div>
 
-```tsx  highlight(4)
+```tsx  highlight="4"
 import * as React from "react"
 import { render } from "react-dom"
 import { Frame } from "framer"
@@ -210,7 +210,7 @@ You should be able to see the `Slider` component now. **Great!** It’s currentl
 
 </div>
 
-```tsx highlight(1-2, 6-8)
+```tsx highlight="1-2, 6-8"
 <Frame
   name={"SliderApp"}
   width={"100%"}
@@ -281,7 +281,7 @@ You also want the **middle** of the knob to sit at the left edge of the rail. To
 
 </div>
 
-```tsx highlight(1-2, 8-18)
+```tsx highlight="1-2, 8-18"
 <Frame
   name={"Rail"}
   width={130}
@@ -319,7 +319,7 @@ Now that you have all the elements of a slider, its time to add dragging to the 
 
 </div>
 
-```tsx highlight(5-11)
+```tsx highlight="5-11"
 <Frame
   name={"Rail"}
   ...
@@ -362,7 +362,7 @@ The knob will now travel from edge-to-edge of the rail with the `x` position ran
 
 </div>
 
-```tsx highlight(1,2, 9-13)
+```tsx highlight="1,2, 9-13"
 <Frame
   name={"Knob"}
   size={40}
@@ -395,7 +395,7 @@ This new `MotionValue` variable will be quite useful in allowing you to keep you
 
 </div>
 
-```tsx highlight(2,5)
+```tsx highlight="2,5"
 import * as React from "react";
 import { Frame, useMotionValue } from "framer";
 
@@ -432,7 +432,7 @@ This whole process occurs outside of the React lifecycle to keep things performa
 
 </div>
 
-```tsx highlight(5-7,9-12,14)
+```tsx highlight="5-7,9-12,14"
     <Frame
       name={"Rail"}
       ...
@@ -483,7 +483,7 @@ The image `Frame` will be set to `center` and have a scale of 25%. It will also 
 
 </div>
 
-```tsx highlight(5-11)
+```tsx highlight="5-11"
 <Frame
   name={"SliderApp"}
   ...
@@ -515,7 +515,7 @@ The `Slider` component won’t control the profile image quite yet. You need to 
 
 </div>
 
-```tsx highlight(2, 8-10, 12)
+```tsx highlight="2, 8-10, 12"
 export function App() {
   const [scale, setScale] = React.useState(0.5);
   return (
@@ -548,7 +548,7 @@ These properties allow you to setup your `Slider` and update the `scale` value o
 
 </div>
 
-```tsx highlight(9-16)
+```tsx highlight="9-16"
 <Frame
   name={"SliderApp"}
   ...
@@ -590,7 +590,7 @@ All errors are gone. **Woo!** In the next few steps you’ll get the `onChange` 
 
 </div>
 
-```tsx highlight(1-7)
+```tsx highlight="1-7"
 export function Slider({
   min = 0,
   max = 1,
@@ -631,7 +631,7 @@ Now that you have the `useTransform()` function imported, let’s put it to work
 
 </div>
 
-```tsx highlight(2-6)
+```tsx highlight="2-6"
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 ```
@@ -656,7 +656,7 @@ You can now call the `onChange()` property safely with `newValue.get()`. Since `
 
 </div>
 
-```tsx highlight(8, 18-19, 21-24)
+```tsx highlight="8, 18-19, 21-24"
 export function Slider({
   min = 0,
   max = 1,
@@ -718,7 +718,7 @@ This will mask your image but, when its scaled you will only be able to view the
 
 </div>
 
-```tsx highlight(1-10, 12-13)
+```tsx highlight="1-10, 12-13"
 <Frame
   name={"Mask"}
   size={120}
@@ -746,7 +746,7 @@ You can now drag the image `frame` inside the mask, but there is one last proble
 
 </div>
 
-```tsx highlight(1-2, 4-7)
+```tsx highlight="1-2, 4-7"
 <Frame
   name={"Image"}
   ...
@@ -775,7 +775,7 @@ Now when you drag your image `Frame` you’ll notice, no matter what the size, t
 
 </div>
 
-```tsx highlight(3, 7-8, 13-19)
+```tsx highlight="3, 7-8, 13-19"
 export function App() {
   const [scale, setScale] = React.useState(0.5);
   const constraint = (480 * scale - 120) / 2;

--- a/pages/tutorial.mdx
+++ b/pages/tutorial.mdx
@@ -188,7 +188,7 @@ Your `App` component needs to know about the `Slider` component so it can be use
 
 </div>
 
-```tsx  highlight="4"
+```tsx  highlight=4
 import * as React from "react"
 import { render } from "react-dom"
 import { Frame } from "framer"
@@ -210,7 +210,7 @@ You should be able to see the `Slider` component now. **Great!** It’s currentl
 
 </div>
 
-```tsx highlight="1-2, 6-8"
+```tsx highlight=1-2,6-8
 <Frame
   name={"SliderApp"}
   width={"100%"}
@@ -281,7 +281,7 @@ You also want the **middle** of the knob to sit at the left edge of the rail. To
 
 </div>
 
-```tsx highlight="1-2, 8-18"
+```tsx highlight=1-2,8-18
 <Frame
   name={"Rail"}
   width={130}
@@ -319,7 +319,7 @@ Now that you have all the elements of a slider, its time to add dragging to the 
 
 </div>
 
-```tsx highlight="5-11"
+```tsx highlight=5-11
 <Frame
   name={"Rail"}
   ...
@@ -362,7 +362,7 @@ The knob will now travel from edge-to-edge of the rail with the `x` position ran
 
 </div>
 
-```tsx highlight="1,2, 9-13"
+```tsx highlight=1,2,9-13
 <Frame
   name={"Knob"}
   size={40}
@@ -395,7 +395,7 @@ This new `MotionValue` variable will be quite useful in allowing you to keep you
 
 </div>
 
-```tsx highlight="2,5"
+```tsx highlight=2,5
 import * as React from "react";
 import { Frame, useMotionValue } from "framer";
 
@@ -432,7 +432,7 @@ This whole process occurs outside of the React lifecycle to keep things performa
 
 </div>
 
-```tsx highlight="5-7,9-12,14"
+```tsx highlight=5-7,9-12,14
     <Frame
       name={"Rail"}
       ...
@@ -483,7 +483,7 @@ The image `Frame` will be set to `center` and have a scale of 25%. It will also 
 
 </div>
 
-```tsx highlight="5-11"
+```tsx highlight=5-11
 <Frame
   name={"SliderApp"}
   ...
@@ -515,7 +515,7 @@ The `Slider` component won’t control the profile image quite yet. You need to 
 
 </div>
 
-```tsx highlight="2, 8-10, 12"
+```tsx highlight=2,8-10,12
 export function App() {
   const [scale, setScale] = React.useState(0.5);
   return (
@@ -548,7 +548,7 @@ These properties allow you to setup your `Slider` and update the `scale` value o
 
 </div>
 
-```tsx highlight="9-16"
+```tsx highlight=9-16
 <Frame
   name={"SliderApp"}
   ...
@@ -590,7 +590,7 @@ All errors are gone. **Woo!** In the next few steps you’ll get the `onChange` 
 
 </div>
 
-```tsx highlight="1-7"
+```tsx highlight=1-7
 export function Slider({
   min = 0,
   max = 1,
@@ -631,7 +631,7 @@ Now that you have the `useTransform()` function imported, let’s put it to work
 
 </div>
 
-```tsx highlight="2-6"
+```tsx highlight=2-6
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 ```
@@ -656,7 +656,7 @@ You can now call the `onChange()` property safely with `newValue.get()`. Since `
 
 </div>
 
-```tsx highlight="8, 18-19, 21-24"
+```tsx highlight=8,18-19,21-24
 export function Slider({
   min = 0,
   max = 1,
@@ -718,7 +718,7 @@ This will mask your image but, when its scaled you will only be able to view the
 
 </div>
 
-```tsx highlight="1-10, 12-13"
+```tsx highlight=1-10,12-13
 <Frame
   name={"Mask"}
   size={120}
@@ -746,7 +746,7 @@ You can now drag the image `frame` inside the mask, but there is one last proble
 
 </div>
 
-```tsx highlight="1-2, 4-7"
+```tsx highlight=1-2,4-7
 <Frame
   name={"Image"}
   ...
@@ -775,7 +775,7 @@ Now when you drag your image `Frame` you’ll notice, no matter what the size, t
 
 </div>
 
-```tsx highlight="3, 7-8, 13-19"
+```tsx highlight=3,7-8,13-19
 export function App() {
   const [scale, setScale] = React.useState(0.5);
   const constraint = (480 * scale - 120) / 2;

--- a/pages/utilities.mdx
+++ b/pages/utilities.mdx
@@ -40,7 +40,7 @@ The `transform` method also supports ranges of more than 2 numbers. Given an inp
 
 </div>
 
-```jsx highlight="2, 5-9"
+```jsx highlight="2,5-9"
 import * as React from "react"
 import { Frame, transform } from "framer"
 
@@ -76,7 +76,7 @@ The `x` value starts at `0`, and we’re converting the horizontal movement of t
 
 </div>
 
-```jsx highlight="2, 5-6, 8"
+```jsx highlight="2,5-6,8"
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 
@@ -106,7 +106,7 @@ In this example, we’re moving a `Frame` four times in a row on every single ta
 
 </div>
 
-```jsx highlight="2, 5, 7-12, 14"
+```jsx highlight="2,5,7-12,14"
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -140,7 +140,7 @@ Finally, we’re adding some default visual properties like `opacity`, `size` an
 
 </div>
 
-```javascript highlight="2, 5, 7-10, 13-28"
+```javascript highlight="2,5,7-10,13-28"
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -223,7 +223,7 @@ Tapping on the Frame will trigger a cycle, causing the Frame to animate to the v
 
 </div>
 
-```jsx highlight="2, 5-9, 11-15, 19-21"
+```jsx highlight="2,5-9, 11-15, 19-21"
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 
@@ -262,7 +262,7 @@ As in the last example, tapping on the Frame will cycle between three values. Ho
 
 </div>
 
-```jsx highlight="11-15, 22"
+```jsx highlight="11-15,22"
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 

--- a/pages/utilities.mdx
+++ b/pages/utilities.mdx
@@ -40,7 +40,7 @@ The `transform` method also supports ranges of more than 2 numbers. Given an inp
 
 </div>
 
-```jsx highlight(2, 5-9)
+```jsx highlight="2, 5-9"
 import * as React from "react"
 import { Frame, transform } from "framer"
 
@@ -76,7 +76,7 @@ The `x` value starts at `0`, and we’re converting the horizontal movement of t
 
 </div>
 
-```jsx highlight(2, 5-6, 8)
+```jsx highlight="2, 5-6, 8"
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 
@@ -106,7 +106,7 @@ In this example, we’re moving a `Frame` four times in a row on every single ta
 
 </div>
 
-```jsx highlight(2, 5, 7-12, 14)
+```jsx highlight="2, 5, 7-12, 14"
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -140,7 +140,7 @@ Finally, we’re adding some default visual properties like `opacity`, `size` an
 
 </div>
 
-```javascript highlight(2, 5, 7-10, 13-28)
+```javascript highlight="2, 5, 7-10, 13-28"
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -223,7 +223,7 @@ Tapping on the Frame will trigger a cycle, causing the Frame to animate to the v
 
 </div>
 
-```jsx highlight(2, 5-9, 11-15, 19-21)
+```jsx highlight="2, 5-9, 11-15, 19-21"
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 
@@ -262,7 +262,7 @@ As in the last example, tapping on the Frame will cycle between three values. Ho
 
 </div>
 
-```jsx highlight(11-15, 22)
+```jsx highlight="11-15, 22"
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 

--- a/pages/utilities.mdx
+++ b/pages/utilities.mdx
@@ -40,7 +40,7 @@ The `transform` method also supports ranges of more than 2 numbers. Given an inp
 
 </div>
 
-```jsx highlight="2,5-9"
+```jsx highlight=2,5-9
 import * as React from "react"
 import { Frame, transform } from "framer"
 
@@ -76,7 +76,7 @@ The `x` value starts at `0`, and we’re converting the horizontal movement of t
 
 </div>
 
-```jsx highlight="2,5-6,8"
+```jsx highlight=2,5-6,8
 import * as React from "react"
 import { Frame, useMotionValue, useTransform } from "framer"
 
@@ -106,7 +106,7 @@ In this example, we’re moving a `Frame` four times in a row on every single ta
 
 </div>
 
-```jsx highlight="2,5,7-12,14"
+```jsx highlight=2,5,7-12,14
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -140,7 +140,7 @@ Finally, we’re adding some default visual properties like `opacity`, `size` an
 
 </div>
 
-```javascript highlight="2,5,7-10,13-28"
+```javascript highlight=2,5,7-10,13-28
 import * as React from "react"
 import { Frame, useAnimation } from "framer"
 
@@ -223,7 +223,7 @@ Tapping on the Frame will trigger a cycle, causing the Frame to animate to the v
 
 </div>
 
-```jsx highlight="2,5-9, 11-15, 19-21"
+```jsx highlight=2,5-9,11-15,19-21
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 
@@ -262,7 +262,7 @@ As in the last example, tapping on the Frame will cycle between three values. Ho
 
 </div>
 
-```jsx highlight="11-15,22"
+```jsx highlight=11-15,22
 import * as React from "react"
 import { Frame, useCycle } from "framer"
 


### PR DESCRIPTION
We have very noisy log output because we were abusing the markdown `metastring` to pass a “highlight” string through to the generated HTML and MDX was unable to parse the unusual strings as prop names. It turns out that MDX supports [passing props](https://mdxjs.com/guides/syntax-highlighting#syntax-highlighting) through to the code blocks for use in custom renderers. Unfortunately we don’t yet support passing a custom `MDXProvider` object to Monobase, however these props are still added to the default HTML as strings.

So:

    ```tsx highlight=12-30
    ... some code ...
    ``` 

Becomes

```
<pre lang="jsx" highlight="12-30">
  <code>...</code>
</pre>
```

So we abuse this and extract the string from the attribute in the highlighter module and do the highlighting as before. The JSX component stays the same.
