### PR TITLE
Feature/upgrade api extractor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: test
           command: |
-            yarn jest
+            make test
 workflows:
   version: 2
   "Build & Test":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ jobs:
           command: |
             make build
       - run:
-          name: test
-          command: |
-            yarn jest
-      - run:
           name: verify-api-references
           command: |
             make verify-api-references
@@ -24,8 +20,19 @@ jobs:
             find ~/repo/build -name '*.html' | xargs yarn ts-node ./test/stylecheck.ts
       - store_artifacts:
           path: ~/repo/build
+  test:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
+      - run:
+          name: test
+          command: |
+            yarn jest
 workflows:
   version: 2
-  "Build":
+  "Build & Test":
     jobs:
       - build
+      - test

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ node_modules/.yarn-integrity: yarn.lock package.json
 .PHONY: bootstrap
 bootstrap: node_modules/.yarn-integrity
 
+.PHONY: test
+test: bootstrap
+	yarn jest
+
 .PHONY: dev
 dev: bootstrap data changelog
 	@$(monobase) serve --project=. --prefix=/api

--- a/api/__tests__/__snapshots__/walker.test.ts.snap
+++ b/api/__tests__/__snapshots__/walker.test.ts.snap
@@ -2,9 +2,8 @@
 
 exports[`walk should generate ids 1`] = `
 Array [
+  "(my_variable:variable)",
   "(myclass:class)",
-  "(myclass:constructor)",
-  "(myclass:constructor).(param1:parameter)",
   "(myclass:class).(mymethod:instance,1)",
   "(myclass:class).(mymethod:instance,1).(param1:parameter)",
   "(myclass:class).(mymethod:instance,2)",
@@ -15,6 +14,8 @@ Array [
   "(myclass:class).(mystaticmethod:static,2)",
   "(myclass:class).(mystaticmethod:static,2).(overloaded1:parameter)",
   "(myclass:class).(mystaticproperty:static)",
+  "(myclass:constructor)",
+  "(myclass:constructor).(param1:parameter)",
   "(myenum:enum)",
   "(myenum:enum).myfield1",
   "(myenum:enum).myfield2",
@@ -42,9 +43,8 @@ Array [
   "(mynamespace:namespace).(mynamespacefunction:function)",
   "(mynamespace:namespace).(mynamespacefunction:function).(param1:parameter)",
   "(mynamespace:namespace).(mynamespaceinterface:interface)",
-  "(mynamespace:namespace).mynamespacetype",
   "(mynamespace:namespace).(mynamespacevariable:variable)",
-  "(my_variable:variable)",
+  "(mynamespace:namespace).mynamespacetype",
   "mytype",
 ]
 `;

--- a/api/__tests__/walker.test.ts
+++ b/api/__tests__/walker.test.ts
@@ -1,16 +1,16 @@
-import * as json from "../__fixtures__/example.api.json"
-import { ApiPackage, ApiItem, ReleaseTag } from "@microsoft/api-extractor-model"
+import { resolve } from "path"
+import { ApiModel, ReleaseTag } from "@microsoft/api-extractor-model"
 import { walk } from "../walker"
 
 describe("walk", () => {
     function createApiPackage() {
-        return ApiItem.deserialize(json as any) as ApiPackage
+        return new ApiModel().loadPackage(resolve(__dirname + "/../__fixtures__/example.api.json"))
     }
 
     it("should generate ids", () => {
         const ids: string[] = []
         const pkg = createApiPackage()
         walk(pkg.entryPoints[0], ReleaseTag.Public, item => ids.push(item.id))
-        expect(ids).toMatchSnapshot()
+        expect(ids.sort()).toMatchSnapshot()
     })
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chokidar-cli": "^1.2.1",
     "classnames": "^2.2.6",
     "framer": "^1.0.15",
-    "framer-motion": "^1.2.6",
+    "framer-motion": "^1.4.0",
     "jest": "^24.3.1",
     "lodash.escape": "^4.0.1",
     "monobase": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@microsoft/api-extractor-model": "^7.1.1",
+    "@microsoft/api-extractor-model": "^7.3.0",
     "@microsoft/tsdoc": "^0.12.9",
     "@types/chalk": "^2.2.0",
     "@types/cheerio": "^0.22.11",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@microsoft/api-extractor-model": "^7.3.0",
-    "@microsoft/tsdoc": "^0.12.11",
+    "@microsoft/tsdoc": "0.12.10",
     "@types/chalk": "^2.2.0",
     "@types/cheerio": "^0.22.11",
     "@types/classnames": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@microsoft/api-extractor-model": "^7.3.0",
-    "@microsoft/tsdoc": "^0.12.9",
+    "@microsoft/tsdoc": "^0.12.11",
     "@types/chalk": "^2.2.0",
     "@types/cheerio": "^0.22.11",
     "@types/classnames": "^2.2.7",

--- a/pages/utilities.mdx
+++ b/pages/utilities.mdx
@@ -24,7 +24,7 @@ export default Template("Utilities")
 
 ## Transform
 
-<APIFunction name="(transform:function)" />
+<APIFunction name="(transform:1)" />
 
 ---
 
@@ -55,7 +55,7 @@ export function MyComponent() {
 
 ---
 
-<APIFunction name="(transform:1)" />
+<APIFunction name="(transform:2)" />
 
 ## useTransform
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,11 +1079,6 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.10.tgz#c0e2c875c24a21da6d345d09189f5df4a1801d82"
   integrity sha512-tsog/HTdM88/WyR0Jz7XWTI0ghbJkt9soFXnQJrINDyaTGzbCoJjRttaW/IY5eAp4eqDyfg++jq6o+byEDOkIQ==
 
-"@microsoft/tsdoc@^0.12.11":
-  version "0.12.11"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.11.tgz#b1384eb544f39e37c4fd5a68b9cbaf5e70739ca9"
-  integrity sha512-CXAEl/mTBkr+KcX/+Xi7wbNBnofZ1p2UwYbaJ+zwcVMCWQTMsheqkOwPM3BQ7J6uOacxwxO6rBRDjQqBdfe8dQ==
-
 "@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,7 +1083,7 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
 
-"@popmotion/popcorn@^0.4.0", "@popmotion/popcorn@^0.4.1":
+"@popmotion/popcorn@^0.4.0":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.1.tgz#02a3aa146dabef4e1bae0567511427fd89fc9cbf"
   integrity sha512-vFqx+NXPGj0iXNUPgxehayiMHR1bOpTqYYF0nypay3J6ltp831hit1ml+OBJYQkk4Dcq3GSQzSokVZdLBQuC5Q==
@@ -1092,6 +1092,16 @@
     framesync "^4.0.4"
     hey-listen "^1.0.8"
     style-value-types "^3.1.5"
+
+"@popmotion/popcorn@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.2.tgz#ff9f5334e8e808ed02237b7b9c928619d1eb68ff"
+  integrity sha512-wu0tEwK3KUZ9BoqfcqC3DfdfRDws/oHXwZKJMVtuhXSrF/PtqvilsPjAk93nh8M+orAnbe8ZyxQmop9+4oJs2g==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    framesync "^4.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -3234,17 +3244,17 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.2.6.tgz#57eebf6a465e0f359a90921b5af4fa1fc10aa7f5"
-  integrity sha512-amlr3TIkAIS1k3rVqGRZzo0RN7qXYxro977dZgspnxLMLBt+ppm9juS/e6Ld0OMwRDgOa3lolofzbt1Z2o97cA==
+framer-motion@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.4.0.tgz#d424f9020a7359ea0711f14bb2b4d69520630d29"
+  integrity sha512-cDyg0nb8A9pSS2kQT2aZXoRWzuRUU6hgfzgEwj4QvGj+qYaz1PRIuokEDpdDm/HGvC2BeI6XzEPi4N6VQTyYoQ==
   dependencies:
     "@popmotion/easing" "^1.0.2"
-    "@popmotion/popcorn" "^0.4.1"
+    "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.4"
     hey-listen "^1.0.8"
-    popmotion "^9.0.0-beta-7"
-    style-value-types "^3.1.5"
+    popmotion "9.0.0-beta-8"
+    style-value-types "^3.1.6"
     stylefire "^6.0.7"
     tslib "^1.10.0"
 
@@ -3253,7 +3263,7 @@ framer@^1.0.15:
   resolved "https://registry.yarnpkg.com/framer/-/framer-1.0.15.tgz#cd9afa540b41a882f8e11300bfb79f7aaaf94046"
   integrity sha512-nX1Oay2ZviLssKmes/6Fxbp4AKZ4i25tq/5ibRkXabMdHlQ+IM6ndfhLFeUmdAml2BeiTR/W/Qzytta2c0QsKg==
 
-framesync@^4.0.0, framesync@^4.0.4:
+framesync@^4.0.0, framesync@^4.0.1, framesync@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
   integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
@@ -5823,16 +5833,16 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
-popmotion@^9.0.0-beta-7:
-  version "9.0.0-beta-7"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-7.tgz#e787e55bf47edccd1eb540eb5ee443b53a166933"
-  integrity sha512-kNDEKgcYBPvGUCKVIslYqhao66hK6fQPTCdjIJag4bAMllqDHM0j0azkFo3+GxhR8YN2LEQOSsEKOZZpeMQlyw==
+popmotion@9.0.0-beta-8:
+  version "9.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
+  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
   dependencies:
     "@popmotion/easing" "^1.0.1"
-    "@popmotion/popcorn" "^0.4.1"
+    "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.4"
     hey-listen "^1.0.8"
-    style-value-types "^3.1.5"
+    style-value-types "^3.1.6"
     tslib "^1.10.0"
 
 port-numbers@^4.0.4:
@@ -6849,6 +6859,13 @@ style-value-types@^3.1.4, style-value-types@^3.1.5:
   integrity sha512-D4ksO88QUxpqiogoyl5nKvFgOpoNZrD4pr0BbZRdS2WsPdVYetdbKUtbsBlwX5mUdfXfoMNuv2pS8h+XRey+Eg==
   dependencies:
     tslib "^1.10.0"
+
+style-value-types@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.6.tgz#6b1da918214d92c74dc7fc2d074013f372b47d76"
+  integrity sha512-AxcfUr/06AHyyyxkNB1O8ypvwa8/qK+sxwelxEN5x+jxW+RXutRE2TuHEQbFq9OBY7ym83CPKvVIsGd6lvKb0Q==
+  dependencies:
+    hey-listen "^1.0.8"
 
 styled-components@^4.1.3:
   version "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.10.tgz#c0e2c875c24a21da6d345d09189f5df4a1801d82"
   integrity sha512-tsog/HTdM88/WyR0Jz7XWTI0ghbJkt9soFXnQJrINDyaTGzbCoJjRttaW/IY5eAp4eqDyfg++jq6o+byEDOkIQ==
 
-"@microsoft/tsdoc@^0.12.9":
-  version "0.12.9"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.9.tgz#f92538bebf649b1b9d00bdd34a9c9971aef17d01"
-  integrity sha512-sDhulvuVk65eMppYOE6fr6mMI6RUqs53KUg9deYzNCBpP+2FhR0OFB5innEfdtSedk0LK+1Ppu6MxkfiNjS/Cw==
+"@microsoft/tsdoc@^0.12.11":
+  version "0.12.11"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.11.tgz#b1384eb544f39e37c4fd5a68b9cbaf5e70739ca9"
+  integrity sha512-CXAEl/mTBkr+KcX/+Xi7wbNBnofZ1p2UwYbaJ+zwcVMCWQTMsheqkOwPM3BQ7J6uOacxwxO6rBRDjQqBdfe8dQ==
 
 "@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,13 +1051,13 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.0.27.tgz#7461e39f8880eceff8f48b0240e6cdc0f01cc8db"
   integrity sha512-sCv3ItE5L6rdpnZR0s69C8KFgz4pmhGsH4de0ZiO+fiCC/L6asuKLubf9QZk3oG3vjebym/V593CE15vRXvvwQ==
 
-"@microsoft/api-extractor-model@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.1.1.tgz#17aa30fe641db7efbcfb779f4a87b8461d6a2322"
-  integrity sha512-RiQJA8JpBbRxqUfro8SxZGLjeCFH8HUUJvD5VTUrDrgdt13omx7d0bsGN0lf+AT63yF+RX4R2+Jd2b0SaAO/sQ==
+"@microsoft/api-extractor-model@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.3.0.tgz#2eab0a3272f40821f1b81deffdca5f6e311b2451"
+  integrity sha512-GfRaGz6d8fPhMOG70l2zS1s6Z8rCxcTHnwfVjb+6ln25eB4fN/jeDRlLKot+HOsVcbxvVseoeB0ZQL9nIsfbXw==
   dependencies:
     "@microsoft/node-core-library" "3.13.0"
-    "@microsoft/tsdoc" "0.12.9"
+    "@microsoft/tsdoc" "0.12.10"
     "@types/node" "8.5.8"
 
 "@microsoft/node-core-library@3.13.0":
@@ -1074,7 +1074,12 @@
     jju "~1.4.0"
     z-schema "~3.18.3"
 
-"@microsoft/tsdoc@0.12.9", "@microsoft/tsdoc@^0.12.9":
+"@microsoft/tsdoc@0.12.10":
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.10.tgz#c0e2c875c24a21da6d345d09189f5df4a1801d82"
+  integrity sha512-tsog/HTdM88/WyR0Jz7XWTI0ghbJkt9soFXnQJrINDyaTGzbCoJjRttaW/IY5eAp4eqDyfg++jq6o+byEDOkIQ==
+
+"@microsoft/tsdoc@^0.12.9":
   version "0.12.9"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.9.tgz#f92538bebf649b1b9d00bdd34a9c9971aef17d01"
   integrity sha512-sDhulvuVk65eMppYOE6fr6mMI6RUqs53KUg9deYzNCBpP+2FhR0OFB5innEfdtSedk0LK+1Ppu6MxkfiNjS/Cw==


### PR DESCRIPTION
I've started the work here: https://github.com/framer/api-docs/pull/49
But because api-extractor removed canonicalReference it is a little bit more involved. We need to duplicate that behaviour ourselves now, but because the canonical reference API was implemented as a static method on every APIItem class, so it's not really easy to copy (see here for a commit that renamed it before they decided to remove it: https://github.com/microsoft/web-build-tools/commit/4e02075ec2f93efca1dacc83a6fb9e6de7db46d8 to see the places it touches)