### PR TITLE
Fix confusing reference "Sandbox.io" in tutorial

### DIFF
--- a/pages/tutorial.mdx
+++ b/pages/tutorial.mdx
@@ -67,10 +67,10 @@ As you progress, things will become more advanced so try to get as far as you ca
 
 <div>
 
-We’ve prepared a starter files for Sandbox.io and Framer X with React and the Framer library setup to help you get started quickly.
+We’ve prepared starter files for CodeSandbox and Framer X with React and the Framer library setup to help you get started quickly.
 
 <Button
-  name="Sandbox Starter File"
+  name="CodeSandbox Starter File"
   link="https://codesandbox.io/s/rrlpv8lo3m"
 />
 
@@ -83,7 +83,7 @@ We’ve prepared a starter files for Sandbox.io and Framer X with React and the 
 
 <br /><br />
 
-- **Sandbox:** Open the starter sandbox and create a fork of the sandbox.
+- **CodeSandbox:** Open the starter sandbox and create a fork of the sandbox.
 - **Framer X:** Download the project and open in Framer X.
 
 Each setup includes two React starter files: `index.tsx` and `Slider.tsx`. Let’s review the files once you have your tutorial setup and ready to go.


### PR DESCRIPTION
The service should be called "CodeSandbox".