### PR TITLE
Remove "size" usage in t example on Scroll page

### DIFF
--- a/pages/scroll.mdx
+++ b/pages/scroll.mdx
@@ -37,7 +37,7 @@ import { Frame, Scroll } from "framer"
 
 export function MyComponent() {
   return (
-    <Scroll size={200}>
+    <Scroll height={200} width={200}>
       <Frame size={300}>Hello World!</Frame>
     </Scroll>
   )


### PR DESCRIPTION
Update the example as we removed `size` from ScrollProps and PageProps: https://github.com/framer/company/issues/12378

related: https://github.com/framer/company/issues/13410