### PR TITLE
Replace `ES6 and React` link

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -38,7 +38,7 @@ const LibraryMenu = () => {
             <MenuItem className="home" href="/pages/index.mdx" title="Introduction" />
             <MenuItem className="guide" href="/pages/tutorial.mdx" title="Tutorial" />
             <MenuItem className="examples" href="/pages/examples.mdx" title="Examples" />
-            <MenuItem className="guide" href="http://bit.ly/framer-react" title="ES6 and React" external />
+            <MenuItem className="guide" href="https://www.framer.com/books/framer-guide-to-react/" title="ES6 and React" external />
 
             <SubTitle name="Library" />
             <MenuItem className="frame" href="/pages/frame.mdx" title="Frame" />


### PR DESCRIPTION
cc @krijnrijshouwer 

Now that the React eBook is published, we should point people there instead of the old Paper doc. I used the full link path here because I'm not sure how a relative path would work in this Navigation component.

---

@aron I added you as a reviewer only because I see you are the most active in this repo. Let me know if someone else is a better reviewer for changes like this or what the process for PR's is! Thanks in advance :)