### PR TITLE
docs: grammatical errors and typos fix

### DIFF
--- a/pages/animation.mdx
+++ b/pages/animation.mdx
@@ -341,7 +341,7 @@ async function sequence() {
 
 ### Dynamic `start`
 
-`start` can also accept a function that can dynamically start each component and the controls are bound to with a different animation definition.
+`start` can also accept a function that can dynamically start each component the controls are bound to with a different animation definition.
 
 Custom data can be sent to this function via the component's `custom` prop.
 

--- a/pages/animation.mdx
+++ b/pages/animation.mdx
@@ -341,7 +341,7 @@ async function sequence() {
 
 ### Dynamic `start`
 
-`start` can also accept a function that can dynamically start each component the controls are bound to with a different animation definition.
+`start` can also accept a function that can dynamically start each component and the controls are bound to with a different animation definition.
 
 Custom data can be sent to this function via the component's `custom` prop.
 

--- a/pages/examples.mdx
+++ b/pages/examples.mdx
@@ -17,7 +17,7 @@ export default Template("Examples")
 
 <div>
 
-The `Frame` is a basic container for layout, styling, animation and events. It’s essentially a `div` element with extra options and smart defaults. Here, you see how easy it is to add visual properties, like `background` and `radius`. Plus, we include shorthand properties that make it easier to quickly customize elements, like `size`, which sets both `width` and `height`.
+The `Frame` is a basic container for layout, styling, animation and events. It’s essentially a `div` element with extra options and smart defaults. Here, you can see how easy it is to add visual properties, like `background` and `radius`. Plus, we include shorthand properties that make it easier to quickly customize elements, like `size`, which sets both `width` and `height`.
 
 <Button
   name="Open Example"
@@ -406,7 +406,7 @@ export function MyComponent() {
 <div>
 
 Here, we’re using two custom Hooks in Framer to transform values from one range to another.
-The `useMotionValue` provides an animatable and sharable value, which we’ll use for the `x` position.
+The `useMotionValue` provides an animatable and shareable value, which we’ll use for the `x` position.
 Then, we’ll transform that value from a range of `[-200, 200]` to a range that makes sense for `scale`.
 Finally, we’ll apply both properties to the `Frame`.
 

--- a/pages/frame.mdx
+++ b/pages/frame.mdx
@@ -264,7 +264,7 @@ The following are properties accepted by the `Frame` component for animation, in
 
 <div>
 
-The `transition` property can be used to customise animations directly on a `Frame`. A `transition` typically defines a single transition that applies to all animating values on that `Frame`. It’s possible to override this `transition` property if a transition is added to an object or `variants` label given to the `animate`, `hover` or `press` properties.
+The `transition` property can be used to customize animations directly on a `Frame`. A `transition` typically defines a single transition that applies to all animating values on that `Frame`. It’s possible to override this `transition` property if a transition is added to an object or `variants` label given to the `animate`, `hover` or `press` properties.
 
 </div>
 
@@ -293,7 +293,7 @@ const transition = {
 }
 ```
 
-You can add orchestration properties like `delay` to affect the whole animation. The numeric value represent seconds.
+You can add orchestration properties like `delay` to affect the whole animation. The numeric value represents seconds.
 
 ```jsx
 const transition = {

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -292,7 +292,7 @@ const sequence = async () => {
 
 ### Dynamic `start`
 
-`start` can also accept a function that can dynamically start each component the controls are bound to with a different animation definition.
+`start` can also accept a function that can dynamically start each component and the controls are bound to with a different animation definition.
 
 Custom data can be sent to this function via the component's `custom` prop.
 

--- a/pages/motion/component.mdx
+++ b/pages/motion/component.mdx
@@ -124,7 +124,7 @@ Transform properties are accelerated by the GPU, and therefore animate smoothly.
 
 For convenience, transform values are applied in a specific order: translate, scale, rotate, skew.
 
-However, you can customise this default order using the [`transformTemplate` prop](#motionprops.transformtemplate).
+However, you can customize this default order using the [`transformTemplate` prop](#motionprops.transformtemplate).
 
 </div>
 

--- a/pages/scroll.mdx
+++ b/pages/scroll.mdx
@@ -50,7 +50,7 @@ export function MyComponent() {
 
 Internally, the Scroll Component wraps all your `children` in a Frame and offsets the position based on your scrolling. For that to work, it needs to be able to calculate the total size of your scroll contents.
 
-It attempts to do so automatically by measuring your added children in the dom using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver). If that is unavailable, it will use a polyfill. If you use `contentWidth` and `contentHeight` it will opt out of this behaviour. You can use this if you need to performantly animate your scroll content size.
+It attempts to do so automatically by measuring your added children in the `DOM` using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver). If that is unavailable, it will use a polyfill. If you use `contentWidth` and `contentHeight` it will opt out of this behaviour. You can use this if you need to performantly animate your scroll content size.
 
 ---
 

--- a/pages/scroll.mdx
+++ b/pages/scroll.mdx
@@ -50,7 +50,7 @@ export function MyComponent() {
 
 Internally, the Scroll Component wraps all your `children` in a Frame and offsets the position based on your scrolling. For that to work, it needs to be able to calculate the total size of your scroll contents.
 
-It attempts to do so automatically by measuring your added children in the `DOM` using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver). If that is unavailable, it will use a polyfill. If you use `contentWidth` and `contentHeight` it will opt out of this behaviour. You can use this if you need to performantly animate your scroll content size.
+It attempts to do so automatically by measuring your added children in the DOM using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver). If that is unavailable, it will use a polyfill. If you use `contentWidth` and `contentHeight` it will opt out of this behaviour. You can use this if you need to performantly animate your scroll content size.
 
 ---
 


### PR DESCRIPTION
Here's what this PR contains:
- [x] Language localization align (e.g. customise -> customize), many instances of `customize` are present in the api-docs
- [x] fix grammatical typos
- [x] re-format (e.g. dom -> `DOM`) 