### PR TITLE
fix: Propagation example docs

### DIFF
--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -184,9 +184,9 @@ return (
     animate="visible"
     variants={list}
   >
-    <motion.li variants={item} />
-    <motion.li variants={item} />
-    <motion.li variants={item} />
+    <motion.li variants={items} />
+    <motion.li variants={items} />
+    <motion.li variants={items} />
   </motion.ul>
 )
 ```


### PR DESCRIPTION
`item` passed into the variants prop which does not exist.