### PR TITLE
Adding Magic Motion documentation

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -18,6 +18,11 @@ const MotionMenu = () => {
 
             <SubTitle name="Components" />
             <MenuItem className="motion" href="/pages/motion/component.mdx" title="motion" />
+            <MenuItem
+                className="animate-shared-layout"
+                href="/pages/motion/animate-shared-layout.mdx"
+                title="AnimateSharedLayout"
+            />
             <MenuItem className="animate-presence" href="/pages/motion/animate-presence.mdx" title="AnimatePresence" />
 
             <SubTitle name="Guides" />

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -54,10 +54,10 @@ This can be used to create a variety of effects, like this underline selection:
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
-Or fully route-driven shared element transitions:
+Or fully route-driven shared element transitions (try pressing back from the overlay):
 
 <iframe
-  src="https://codesandbox.io/embed/framer-motion-magic-motion-app-store-demo-su6mx?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-app-store-demo-su6mx?fontsize=14&hidenavigation=0&theme=dark"
   style={{
     width: "100%",
     height: "500px",

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -1,0 +1,159 @@
+<!-- 👋 Editing this file? Need help? → https://github.com/framer/api-docs/blob/master/CONTRIBUTING.md -->
+
+import {
+  APIClass,
+  APIVariable,
+  APIFunction,
+  APIMethod,
+  APIInterface,
+  APIProperty,
+  APIMergedInterface,
+  Template,
+  Link,
+  Ref,
+  Callout,
+  Todo,
+  Button,
+  EmbeddedExample,
+} from "../../components"
+import { AnimatePresenceExample } from "../../components/examples/motion"
+
+export default Template("AnimateSharedLayout")
+
+# AnimateSharedLayout
+
+<span className="lead">
+  Animate between different components that share a layout
+  ID.
+</span>
+
+<Callout>
+  <strong>Note:</strong> This feature is currently in beta.
+  You can install the latest Framer Motion 2 beta using{" "}
+  <code>npm install framer-motion@beta</code>.
+</Callout>
+
+<div>
+
+`AnimateSharedLayout` allows new components to animate out from other components that share the same `layoutId`.
+
+This can be used to create a variety of effects, like this underline selection:
+
+<iframe
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-underline-menu-demo-y6tl3?fontsize=14&hidenavigation=1&theme=dark"
+  style={{
+    width: "100%",
+    height: "500px",
+    border: 0,
+    borderRadius: 4,
+    overflow: "hidden",
+    marginBottom: 40,
+  }}
+  title="Framer Motion: Magic Motion underline menu demo"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+Or fully route-driven shared element transitions:
+
+<iframe
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-app-store-demo-su6mx?fontsize=14&hidenavigation=1&theme=dark"
+  style={{
+    width: "100%",
+    height: "500px",
+    border: 0,
+    borderRadius: 4,
+    overflow: "hidden",
+    marginBottom: 40,
+  }}
+  title="Framer Motion: Magic Motion App Store demo"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+</div>
+
+---
+
+## Usage
+
+### Shared layout animations
+
+When a new component is added with an existing `layoutId`, on mount it will visually animate out from the previous component that had that `layoutId`.
+
+```jsx
+import { motion, AnimateSharedLayout } from "framer-motion"
+
+export const MyComponent = ({ items, selectedId }) => (
+  <AnimateSharedLayout>
+    {items.map(item => (
+      <li>
+        {item.title}
+        {item.id === selectedId && (
+          <motion.div layoutId="underline" />
+        )}
+      </li>
+    ))}
+  </AnimateSharedLayout>
+)
+```
+
+If the previous component still exists in the tree, it'll automatically be hidden using `opacity: 0`, but still occupy space in the layout.
+
+### Exit animations
+
+When a component that's expected to enter and exit the tree is wrapped in `AnimatePresence`, it'll automatically animate back to the original component with its `layoutId` when it's removed.
+
+```jsx
+<AnimateSharedLayout>
+  {images.map((img) => <motion.img layoutId={img.id} />)}
+  <AnimatePresence>
+    {selectedId && <motion.img layoutId={selectedId} />)}
+  </AnimatePresence>
+</AnimateSharedLayout>
+```
+
+### Crossfade
+
+Sometimes, the components that you're animating from/to might look different enough that when an entering/exiting component is added or removed there's an obvious visual switch. For instance, a text box might be wrapped differently in one layout than another.
+
+By setting `type="crossfade"`, both the exiting and previous components will animate together. The root components in each stack that has either `animate={true}` or a `layoutId` will crossfade, so one gets hidden as the other is revealed.
+
+```jsx
+<AnimateSharedLayout type="crossfade">
+  {images.map((img) => <motion.img layoutId={img.id} />)}
+  <AnimatePresence>
+    {selectedId && <motion.img layoutId={selectedId} />)}
+  </AnimatePresence>
+</AnimateSharedLayout>
+```
+
+### Transition customisation
+
+<div>
+
+The transition used for the shared layout animation is defined in the component's `transition` prop.
+
+This accepts all the same `Transition` settings as usual, with the exceptions that you can only set a single transition for all child components and individual values aren't supported. These limitations will be removed in a future release.
+
+</div>
+
+```jsx
+<AnimateSharedLayout transition={{ duration: 2 }}>
+```
+
+### Correcting visual distortion
+
+For maximum performance, layouts are animated using the `transform` property. Animating `width` and `height` using `scaleX` and `scaleY` can introduce visual distortion on children.
+
+This can be automatically corrected by making those children `motion` components with `animate={true}`.
+
+```jsx
+<motion.div animate />
+```
+
+<!--
+TODO:
+Add a Props section once this repo is upgraded to 2.0.0
+Which we can't do until it's on `latest`.
+-->

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -126,7 +126,7 @@ When a component that's expected to enter and exit the tree is wrapped in `Anima
 
 <div>
 
-Sometimes, the components that you're animating from/to might look different enough that when an entering/exiting component is added or removed there's an obvious visual switch. For instance, a text box might be wrapped differently in one layout than another.
+Sometimes, the components that you are animating from/to might look different enough that when an entering/exiting component is added or removed there is an obvious visual switch. For instance, a text box might be wrapped differently in one layout than another.
 
 By setting `type="crossfade"`, both the exiting and previous components will animate together. The root components in each stack that has either `animate={true}` or a `layoutId` will crossfade, so one gets hidden as the other is revealed.
 

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -152,7 +152,7 @@ By setting `type="crossfade"`, both the exiting and previous components will ani
 
 The transition used for the shared layout animation is defined in the component's `transition` prop.
 
-This accepts all the same `Transition` settings as usual, with the exceptions that you can only set a single transition for all child components and individual values aren't supported. These limitations will be removed in a future release.
+This accepts all the same `Transition` settings as usual, with the limitations that you can only set a single transition for all child components and individual values aren't supported. These limitations will be removed in a future release.
 
 </div>
 

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -35,7 +35,9 @@ export default Template("AnimateSharedLayout")
 
 <div>
 
-`AnimateSharedLayout` allows new components to animate out from other components that share the same `layoutId`.
+`AnimateSharedLayout` allows animation between seperate components.
+
+These components do not need to be rendered in the same hierarchy, as long as they share the same `layoutId`, and are wrapped within the same `AnimateSharedLayout` component.
 
 This can be used to create a variety of effects, like this underline selection:
 

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -79,7 +79,7 @@ Or fully route-driven shared element transitions:
 
 ### Shared layout animations
 
-When a new component is added with an existing `layoutId`, on mount it will visually animate out from the previous component that had that `layoutId`.
+When a new component is added with an existing `layoutId`, on mount it will visually animate out from the previous component that had or has the same `layoutId`.
 
 ```jsx
 import { motion, AnimateSharedLayout } from "framer-motion"
@@ -102,7 +102,16 @@ If the previous component still exists in the tree, it'll automatically be hidde
 
 ### Exit animations
 
+<div>
+
 When a component that's expected to enter and exit the tree is wrapped in `AnimatePresence`, it'll automatically animate back to the original component with its `layoutId` when it's removed.
+
+<Button
+  name="Open example in CodeSandbox"
+  link="https://codesandbox.io/s/framer-motion-magic-motion-gallery-demo-pknk7"
+/>
+
+</div>
 
 ```jsx
 <AnimateSharedLayout>
@@ -115,9 +124,18 @@ When a component that's expected to enter and exit the tree is wrapped in `Anima
 
 ### Crossfade
 
+<div>
+
 Sometimes, the components that you're animating from/to might look different enough that when an entering/exiting component is added or removed there's an obvious visual switch. For instance, a text box might be wrapped differently in one layout than another.
 
 By setting `type="crossfade"`, both the exiting and previous components will animate together. The root components in each stack that has either `animate={true}` or a `layoutId` will crossfade, so one gets hidden as the other is revealed.
+
+<Button
+  name="Open example in CodeSandbox"
+  link="https://codesandbox.io/s/framer-motion-magic-motion-app-store-demo-su6mx"
+/>
+
+</div>
 
 ```jsx
 <AnimateSharedLayout type="crossfade">

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -150,7 +150,7 @@ By setting `type="crossfade"`, both the exiting and previous components will ani
 
 <div>
 
-The transition used for the shared layout animation is defined in the component's `transition` prop.
+The transition used for the shared layout animation is defined in the [component's `transition` prop](/api/motion/types#transition).
 
 This accepts all the same `Transition` settings as usual. Currently it is only possible to set a single transition for all child components. Using individual values per child component is not supported. This limitation will be removed in a future release.
 
@@ -164,10 +164,12 @@ This accepts all the same `Transition` settings as usual. Currently it is only p
 
 For maximum performance, layouts are animated using the `transform` property. Animating `width` and `height` using `scaleX` and `scaleY` can introduce visual distortion on children.
 
-This can be automatically corrected by making those children `motion` components with `animate={true}`.
+This can be automatically corrected by applying `animate` to those children.
 
 ```jsx
-<motion.div animate />
+<motion.div sharedId="container">
+  <motion.div animate />
+</motion.div>
 ```
 
 <!--

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -152,7 +152,7 @@ By setting `type="crossfade"`, both the exiting and previous components will ani
 
 The transition used for the shared layout animation is defined in the component's `transition` prop.
 
-This accepts all the same `Transition` settings as usual, with the limitations that you can only set a single transition for all child components and individual values aren't supported. These limitations will be removed in a future release.
+This accepts all the same `Transition` settings as usual. Currently it is only possible to set a single transition for all child components. Using individual values per child component is not supported. This limitation will be removed in a future release.
 
 </div>
 

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -398,5 +398,5 @@ The styles that will automatically animate are:
 
 - **Transform:** `animate` **doesn't** currently automatically animate `transform`, because the `transform` prop is currently reserved for performing layout animations.
 - **Drag:** The `layoutTransition` prop that `animate={true}` replaces used to have a hacky way to integrate it with `drag` that powered the drag-to-reorder demos. The plan is to properly fix integration with `drag` rather than re-expose this kind of API.
-- **Inline components:** Components that are set to `display: inline` aren't compatible with layout animations as they don't accept the CSS `transform` property. Try `display: inline-block` instead.
+- **Inline components:** Components that are set to `display: inline` aren't compatible with layout animations as they don't accept the CSS `transform` property. Try using `display: inline-block` instead.
 - **SVG:** SVGs are currently not supported, but they will be soon.

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -44,23 +44,6 @@ export const MyComponent = () => (
 )
 ```
 
-<Callout>
-  <ul>
-    <li>
-      <a href="#target-object">Target object</a>
-    </li>
-    <li>
-      <a href="#variants">Variants</a>
-    </li>
-    <li>
-      <a href="#animation-controls">Controls</a>
-    </li>
-    <li>
-      <a href="#automatic-(beta)">Automatic (beta)</a>
-    </li>
-  </ul>
-</Callout>
-
 ---
 
 ## Target object

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -361,7 +361,7 @@ For example, this component is animated by switching `justify-content` between `
 
 For maximum performance, all layout animations are performed using the `transform` property rather than expensive layout-triggering properties like `width` or `top`.
 
-Animating `width` and `height` with `scaleX` and `scaleY` can sometimes visually distort children. This can be corrected by setting `animate` on those, too:
+Animating `width` and `height` with `scaleX` and `scaleY` can sometimes visually distort children. You can correct this by also applying `animate` to those children if they are motion elements:
 
 ```jsx
 <motion.div animate>

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -20,15 +20,16 @@ export default Template("Animation")
 # Animation
 
 <span className="lead">
-  A set of properties and helpers for high-performance,
-  declarative animations.
+  How to animate in Framer Motion.
 </span>
 
 <div>
 
-Animations in Motion are primarily controlled via the `motion` component's `animate` property.
+Animations in Framer Motion are controlled via the `motion` component's flexible `animate` property.
 
-It can accept a target object, variant label(s), or imperative animation controls. We'll explore each on this page.
+It can be used in a number of ways, scaling to the complexity of your needs.
+
+In this guide, we'll explore each of them.
 
 </div>
 
@@ -43,11 +44,28 @@ export const MyComponent = () => (
 )
 ```
 
+<Callout>
+  <ul>
+    <li>
+      <a href="#target-object">Target object</a>
+    </li>
+    <li>
+      <a href="#variants">Variants</a>
+    </li>
+    <li>
+      <a href="#animation-controls">Controls</a>
+    </li>
+    <li>
+      <a href="#automatic-(beta)">Automatic (beta)</a>
+    </li>
+  </ul>
+</Callout>
+
 ---
 
 ## Target object
 
-The simplest way to make a component animate is to pass a target object to a component's `animate` prop.
+For simple animations, we can set values directly on the `animate` prop.
 
 ```jsx
 <motion.div animate={{ x: 100 }} />
@@ -315,3 +333,88 @@ return (
   </ul>
 )
 ```
+
+---
+
+## Automatic (beta)
+
+<Callout>
+  <strong>Note:</strong> This feature is currently in beta.
+  You can install the latest Framer Motion 2 beta using{" "}
+  <code>npm install framer-motion@beta</code>.
+</Callout>
+
+<div>
+
+A `motion` component can automatically animate layout and style changes that occur as a result of a re-render by setting `animate` to `true`.
+
+These layout and style changes can be set via CSS applied via `className`, `style`, or inherited from a stylesheet.
+
+</div>
+
+```jsx
+<motion.div animate />
+```
+
+### Layout animations
+
+When a component is in automatic animation mode, any changes to its layout will animate automatically.
+
+These layout changes can be anything: A change in the component's parent's flexbox, CSS grid, switching between `position: absolute` and `position: fixed`.
+
+For example, this component is animated by switching `justify-content` between `flex-start` and `flex-end`:
+
+<iframe
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-switch-demo-0d68e?fontsize=14&hidenavigation=1&theme=dark"
+  style={{
+    width: "100%",
+    height: "500px",
+    border: 0,
+    borderRadius: 4,
+    overflow: "hidden",
+  }}
+  title="Framer Motion: Magic Motion switch demo"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+For maximum performance, all layout animations are performed using the `transform` property rather than expensive layout-triggering properties like `width` or `top`.
+
+Animating `width` and `height` with `scaleX` and `scaleY` can sometimes visually distort children. This can be corrected by setting `animate` on those, too:
+
+```jsx
+<motion.div animate>
+  <motion.div animate />
+</motion.div>
+```
+
+<iframe
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-accordion-demo-tqzul?fontsize=14&hidenavigation=1&theme=dark"
+  style={{
+    width: "100%",
+    height: "500px",
+    border: 0,
+    borderRadius: 4,
+    overflow: "hidden",
+  }}
+  title="Framer Motion: Magic Motion accordion demo"
+  allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+### Style animations
+
+The styles that will automatically animate are:
+
+- `backgroundColor`
+- `borderRadius` (and individual corners)
+- `boxShadow` (currently single shadow only)
+- `color`
+- `opacity`
+
+### Limitations
+
+- **Transform:** `animate` **doesn't** currently automatically animate `transform`, because the `transform` prop is currently reserved for performing layout animations.
+- **Drag:** The `layoutTransition` prop that `animate={true}` replaces used to have a hacky way to integrate it with `drag` that powered the drag-to-reorder demos. The plan is to properly fix integration with `drag` rather than re-expose this kind of API.
+- **Inline components:** Components that are set to `display: inline` aren't compatible with layout animations as they don't accept the CSS `transform` property. Try `display: inline-block` instead.
+- **SVG:** SVGs aren't currently supported, but they will be soon.

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -341,9 +341,7 @@ These layout and style changes can be set via CSS applied via `className`, `styl
 
 ### Layout animations
 
-When a component is in automatic animation mode, any changes to its layout will animate automatically.
-
-These layout changes can be anything: A change in the component's parent's flexbox, CSS grid, switching between `position: absolute` and `position: fixed`.
+Auto-animating components will animate any changes to their layout. These layout changes can be anything: A change in the component's parent's flexbox, CSS grid, or switching between `position: absolute` and `position: fixed`.
 
 For example, this component is animated by switching `justify-content` between `flex-start` and `flex-end`:
 

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -394,7 +394,7 @@ The styles that will automatically animate are:
 - `color`
 - `opacity`
 
-### Limitations
+### Current limitations
 
 - **Transform:** `animate` **doesn't** currently automatically animate `transform`, because the `transform` prop is currently reserved for performing layout animations.
 - **Drag:** The `layoutTransition` prop that `animate={true}` replaces used to have a hacky way to integrate it with `drag` that powered the drag-to-reorder demos. The plan is to properly fix integration with `drag` rather than re-expose this kind of API.

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -60,7 +60,7 @@ When any value in `animate` changes, the component will automatically animate to
 
 By default, Motion will create an appropriate animation for a snappy transition based on the types of value being animated. For instance, physical properties like `x` or `scale` will be animated via a spring simulation. Whereas values like `opacity` or `color` will be animated with a tween.
 
-However, you can set different types of animation by passing a `Transition` to the `transition` prop.
+However, you can set different types of animation by passing a [`Transition` to the `transition` prop](/api/motion/types#transition).
 
 ```jsx
 <motion.div

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -360,7 +360,7 @@ For example, this component is animated by switching `justify-content` between `
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
-For maximum performance, all layout animations are performed using the `transform` property rather than expensive layout-triggering properties like `width` or `top`.
+All layout animations are performed using the `transform` property rather than properties like `width` or `top`. This results in smoother animations, because it does not trigger expensive layouts during the animation.
 
 Animating `width` and `height` with `scaleX` and `scaleY` can sometimes visually distort children. You can correct this by also applying `animate` to those children if they are motion elements:
 

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -353,6 +353,7 @@ For example, this component is animated by switching `justify-content` between `
     border: 0,
     borderRadius: 4,
     overflow: "hidden",
+    marginBottom: 40,
   }}
   title="Framer Motion: Magic Motion switch demo"
   allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -341,7 +341,7 @@ These layout and style changes can be set via CSS applied via `className`, `styl
 
 ### Layout animations
 
-Auto-animating components will animate any changes to their layout. These layout changes can be anything: A change in the component's parent's flexbox, CSS grid, or switching between `position: absolute` and `position: fixed`.
+Auto-animating components will animate any changes to their layout. These layout changes can be anything: a change in the component's parent's flexbox, CSS grid, or switching between `position: absolute` and `position: fixed`.
 
 For example, this component is animated by switching `justify-content` between `flex-start` and `flex-end`:
 

--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -399,4 +399,4 @@ The styles that will automatically animate are:
 - **Transform:** `animate` **doesn't** currently automatically animate `transform`, because the `transform` prop is currently reserved for performing layout animations.
 - **Drag:** The `layoutTransition` prop that `animate={true}` replaces used to have a hacky way to integrate it with `drag` that powered the drag-to-reorder demos. The plan is to properly fix integration with `drag` rather than re-expose this kind of API.
 - **Inline components:** Components that are set to `display: inline` aren't compatible with layout animations as they don't accept the CSS `transform` property. Try `display: inline-block` instead.
-- **SVG:** SVGs aren't currently supported, but they will be soon.
+- **SVG:** SVGs are currently not supported, but they will be soon.


### PR DESCRIPTION
Provides documentation for the new auto `animate` prop and `AnimateSharedLayout`. I think the Magic Move connection can be made in the Handoff guide once these are in master.