### PR TITLE
Hide devtools in codesandbox embed

### DIFF
--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -42,7 +42,7 @@ These components do not need to be rendered in the same hierarchy, as long as th
 This can be used to create a variety of effects, like this underline selection:
 
 <iframe
-  src="https://codesandbox.io/embed/framer-motion-magic-motion-underline-menu-demo-y6tl3?fontsize=14&hidenavigation=1&theme=dark&hidedevtools=1"
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-underline-menu-demo-y6tl3?fontsize=14&hidenavigation=1&hidedevtools=1&theme=dark"
   style={{
     width: "100%",
     height: "500px",
@@ -59,7 +59,7 @@ This can be used to create a variety of effects, like this underline selection:
 Or fully route-driven shared element transitions (try pressing back from the overlay):
 
 <iframe
-  src="https://codesandbox.io/embed/framer-motion-magic-motion-app-store-demo-su6mx?fontsize=14&hidenavigation=0&theme=dark"
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-app-store-demo-su6mx?fontsize=14&hidenavigation=0&hidedevtools=1&theme=dark"
   style={{
     width: "100%",
     height: "500px",

--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -42,7 +42,7 @@ These components do not need to be rendered in the same hierarchy, as long as th
 This can be used to create a variety of effects, like this underline selection:
 
 <iframe
-  src="https://codesandbox.io/embed/framer-motion-magic-motion-underline-menu-demo-y6tl3?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/framer-motion-magic-motion-underline-menu-demo-y6tl3?fontsize=14&hidenavigation=1&theme=dark&hidedevtools=1"
   style={{
     width: "100%",
     height: "500px",


### PR DESCRIPTION
Hey!

Just wanted to let you folks know that it's possible to hide the devtools when unnecessary with `hidedevtools=1` for a more minimal look.

The example for `AnimateSharedLayout ` doesn't look like it needs it : https://www.framer.com/api/motion/animate-shared-layout