### PR TITLE
Fix typo in useReducedMotion utilities docs.

### DIFF
--- a/pages/motion/guide-accessibility.mdx
+++ b/pages/motion/guide-accessibility.mdx
@@ -48,6 +48,7 @@ We can achieve this in Framer Motion by passing different values to `animate` ba
 
 </div>
 
+
 ```jsx
 function Sidebar({ isOpen }) {
   const shouldReduceMotion = useReducedMotion()


### PR DESCRIPTION
I can't seem to find the MDX file for useReducedMotion but the docs page has a typo.

Typo is => isOpem, should say isOpen

https://www.framer.com/api/motion/utilities/#usereducedmotion

<img width="502" alt="Screen Shot 2020-05-13 at 2 30 57 PM" src="https://user-images.githubusercontent.com/12755042/81857283-a9028800-9527-11ea-9787-515c5eb46c9b.png">
