### PR TITLE
Add note about `exitBeforeEnter` prop to Exit Animations

### DIFF
--- a/pages/motion/examples.mdx
+++ b/pages/motion/examples.mdx
@@ -337,6 +337,8 @@ export const Slideshow = ({ image }) => (
 )
 ```
 
+You can also add the `exitBeforeEnter` prop to `AnimatePresence` if you'd like the entrace animation to wait until the exit animation has ended before starting.
+
 ---
 
 ## Position transitions


### PR DESCRIPTION
This just adds a small note about the `exitBeforeEnter` prop which I had to do a bunch of Googling for to realize existed and would solve my problem. I think this is probably a fairly common use case to need to have pages/screen slide in and out.