### PR TITLE
Add documentation for useIsPresent

### DIFF
--- a/pages/motion/animate-presence.mdx
+++ b/pages/motion/animate-presence.mdx
@@ -206,3 +206,9 @@ export const MyComponent = ({ items }) => (
 ## usePresence
 
 <APIFunction name="usePresence" />
+
+---
+
+## useIsPresent
+
+<APIFunction name="useIsPresent" />

--- a/pages/motion/utilities.mdx
+++ b/pages/motion/utilities.mdx
@@ -47,6 +47,12 @@ export default Template("Utilities")
 
 ---
 
+## useIsPresent
+
+<APIFunction name="useIsPresent" />
+
+---
+
 ## useDragControls
 
 <APIFunction name="useDragControls" />


### PR DESCRIPTION
Following up on [framer/motion #753](https://github.com/framer/motion/pull/753#issue-480957865).

Adds documentation for `useIsPresent`.