### PR TITLE
fix: typo in transformTemplate

### DIFF
--- a/pages/motion/component.mdx
+++ b/pages/motion/component.mdx
@@ -131,7 +131,7 @@ However, you can customize this default order using the [`transformTemplate` pro
 
 ```jsx
 function template({ rotate, x }) {
-  return `rotate(${rotate}deg) translateX(${x}px)`
+  return `rotate(${rotate}) translateX(${x})`
 }
 
 return (


### PR DESCRIPTION
I just tried it and the units are part of the variables.