### PR TITLE
Add examples to framer/navigation and motion/gestures

### DIFF
--- a/pages/motion/gestures.mdx
+++ b/pages/motion/gestures.mdx
@@ -13,6 +13,7 @@ import {
   Ref,
   Callout,
   Todo,
+  Button,
 } from "../../components"
 
 export default Template("Gestures")
@@ -174,6 +175,12 @@ In this model, you can still animate and adjust `x` and `y`, but they will be **
 <APIProperty name="DraggableProps.dragTransition" />
 <APIProperty name="DraggableProps.dragPropagation" />
 <APIProperty name="DraggableProps.dragControls" />
+<div>
+<Button
+  name="Open example file"
+  link="https://framer.com/projects/API-useDragControls--uRarZCGZukBTTqSu15Va-fRvnB?node=lKPPsks8l"
+/>
+</div>
 
 <APIMethod name="DragHandlers.onDrag()" />
 <APIMethod name="DragHandlers.onDragStart()" />

--- a/pages/navigation.mdx
+++ b/pages/navigation.mdx
@@ -5,6 +5,7 @@ import {
   APIEnumField,
   Template,
   Callout,
+  Button
 } from "../components"
 import { ReleaseBadge } from "../components/documentation/ReleaseBadge"
 
@@ -22,6 +23,7 @@ Expressing flows is an important part of the prototyping process, and easy to se
 <Callout>
   <strong>Note:</strong> The Navigation API is still currently in Beta. Please reach out to <a href="https://framer.com/support">support@framer.com</a> with any issues.
 </Callout>
+
 ---
 
 <!-- ## useNavigation -->
@@ -48,6 +50,8 @@ export function Button() {
 
 ---
 
+
+
 <!-- ## Transitions -->
 
 <h2>Transitions <ReleaseBadge releaseTag="beta" /></h2>
@@ -61,6 +65,13 @@ import { ComponentInstance } from "./canvas"
 To reference a Component Instance in code, you’ll need to first [create a Design Component](https://www.framer.com/support/using-framer/design-components/), and import it into your Code Component or Override file.
 
 Certain transitions can also accept more arguments to customize it’s behavior. Continue reading to learn more about the properties that can be customized.
+
+<div>
+<Button
+  name="Open example file"
+  link="https://framer.com/projects/new?duplicate=r5n441GCUggw1iJYT883"
+/>
+</div>
 
 ---
 

--- a/pages/navigation.mdx
+++ b/pages/navigation.mdx
@@ -19,10 +19,19 @@ export default Template("Navigation Controls")
 </span>
 
 Expressing flows is an important part of the prototyping process, and easy to set up in Framer. Continue reading to learn how to set up your own flows, or create something new for your project.
+<div>
+<Button
+  name="Open example file"
+  link="https://framer.com/projects/new?duplicate=r5n441GCUggw1iJYT883"
+/>
+</div>
 
 <Callout>
-  <strong>Note:</strong> The Navigation API is still currently in Beta. Please reach out to <a href="https://framer.com/support">support@framer.com</a> with any issues.
+  <strong>Note:</strong> The recommended way to navigate from code is to instead add <a href="https://www.framer.com/api/property-controls/#event-handler">an EventHandler property control</a> to a code component. <br/><br/>
+  
+  The following Navigation API is currently in Beta. Please reach out to <a href="https://framer.com/support">support@framer.com</a> with any issues.
 </Callout>
+
 
 ---
 
@@ -66,12 +75,6 @@ To reference a Component Instance in code, you’ll need to first [create a Desi
 
 Certain transitions can also accept more arguments to customize it’s behavior. Continue reading to learn more about the properties that can be customized.
 
-<div>
-<Button
-  name="Open example file"
-  link="https://framer.com/projects/new?duplicate=r5n441GCUggw1iJYT883"
-/>
-</div>
 
 ---
 

--- a/pages/page.mdx
+++ b/pages/page.mdx
@@ -79,7 +79,7 @@ export function MyComponent() {
 
 ## Effects
 
-The `Page` component comes with a set of pagination effects that change how pages look as animate as you scroll through them. You can also create custom effects of your own.
+The `Page` component comes with a set of pagination effects that change how pages look and animate as you scroll through them. You can also create custom effects of your own.
 
 ### None
 


### PR DESCRIPTION
This adds two example project files to:

/api/navigation/#transitions
/api/motion/gestures/#draggableprops.dragcontrols

And also fixes a typo
