### PR TITLE
Update all 'static.framer.com' links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="https://static.framer.com/repos/api-logo.png" width="40"/>
+    <img src="https://misc.framerstatic.com/repos/api-logo.png" width="40"/>
     <br>
     Contributing
 </h1>
@@ -16,7 +16,7 @@ The pages use the [mdx][#mdx] format which is a combination of
 API documentation. Though having a basic understanding of markdown should be
 enough to make a simple edit.
 
-![The GitHub Editor](https://static.framer.com/repos/contributing/github-editor.png)
+![The GitHub Editor](https://misc.framerstatic.com/repos/contributing/github-editor.png)
 
 Once you've made your edit scroll down to the bottom of the editor. To find
 the submission form (titled "Commit Changes"). You'll see a different form
@@ -24,12 +24,12 @@ depending on whether your a member of the Framer team or not. In either case
 fill in a short summary of the changes made and click the "Propose file
 change" button.
 
-![The Commit Form](https://static.framer.com/repos/contributing/guest-commit-ui.png)
+![The Commit Form](https://misc.framerstatic.com/repos/contributing/guest-commit-ui.png)
 
 If you're a member of the Framer team, you'll need to select the second
 option, "Create a new branch...", to open a ticket for review.
 
-![The Team Form](https://static.framer.com/repos/contributing/team-commit-ui.png)
+![The Team Form](https://misc.framerstatic.com/repos/contributing/team-commit-ui.png)
 
 This will then open a ticket for the project maintainers to review before
 publishing the changes.
@@ -43,7 +43,7 @@ publishing the changes.
 New pages can be added to the documentation by navigating to the **/pages/api** directory
 in the GitHub repository and clicking the "Create new file" button.
 
-![Create New File](https://static.framer.com/repos/contributing/new-file-ui.png)
+![Create New File](https://misc.framerstatic.com/repos/contributing/new-file-ui.png)
 
 Give your file a name with the `.mdx` file extension, for example (color.mdx).
 You'll then need to include the generic boilerplate for a page.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="https://static.framer.com/repos/logo-dark.png" width="40"/>
+    <img src="https://misc.framerstatic.com/repos/logo-dark.png" width="40"/>
     <br>
     API Docs
 </h1>
@@ -15,7 +15,7 @@ website at [framer.com/api/][#website]
 [#monobase]: https://github.com/koenbok/monobase/
 [#website]: https://framer.com/api/
 
-<img src="https://static.framer.com/repos/api.png" />
+<img src="https://misc.framerstatic.com/repos/api.png" />
 
 ## Contributing
 

--- a/components/Template.tsx
+++ b/components/Template.tsx
@@ -140,7 +140,7 @@ export const Page: React.FunctionComponent<{ title?: string; showEdit?: boolean 
         : "A JavaScript library for rapid interactive prototyping for web and mobile."
     const socialImage = isMotion()
         ? "https://framer.com/static/images/social/motion.png"
-        : "https://static.framer.com/api/social.png"
+        : "https://misc.framerstatic.com/api/social.png"
 
     // Use path gives the page name
     if (showEdit === undefined) {
@@ -185,7 +185,7 @@ export const Page: React.FunctionComponent<{ title?: string; showEdit?: boolean 
                     <link rel="stylesheet" href={urlFor("/static/styles/highlight.css")} />
                     <link rel="stylesheet" href={urlFor("/static/styles/reset.css")} />
                     <link rel="stylesheet" href={urlFor("/static/styles/global.css")} />
-                    <link rel="shortcut icon" href="https://static.framer.com/api/favicon.ico" />
+                    <link rel="shortcut icon" href="https://misc.framerstatic.com/api/favicon.ico" />
 
                     <meta content="width=device-width, initial-scale=1" name="viewport" />
                     <StyledSheet app={body} />

--- a/components/tutorial/SliderComplete.tsx
+++ b/components/tutorial/SliderComplete.tsx
@@ -47,7 +47,7 @@ export const SliderComplete = Dynamic(function SliderComplete() {
                     center
                     size={imageSize}
                     // background={maskBg}
-                    image="https://static.framer.com/api/bg.jpg"
+                    image="https://misc.framerstatic.com/api/bg.jpg"
                     drag
                     dragElastic={0}
                     dragMomentum={false}

--- a/components/tutorial/SliderData.tsx
+++ b/components/tutorial/SliderData.tsx
@@ -45,7 +45,7 @@ export const SliderData = Dynamic(function SliderData() {
                 center
                 size={imageSize}
                 // background={maskBg}
-                image="https://static.framer.com/api/bg.jpg"
+                image="https://misc.framerstatic.com/api/bg.jpg"
                 style={{ ...noMarginAdded, backgroundColor: maskBg }}
             />
 

--- a/components/tutorial/SliderStarter.tsx
+++ b/components/tutorial/SliderStarter.tsx
@@ -8,7 +8,7 @@ export const SliderStarter = Dynamic(function SliderStarter() {
     const noMarginAdded = { margin: 0 }
     return hasFramer ? (
         <Frame width="300px" height="300px" background="" style={noMarginAdded}>
-            <Frame center image="https://static.framer.com/api/logo.jpg" radius={4} borderRadius={4} />
+            <Frame center image="https://misc.framerstatic.com/api/logo.jpg" radius={4} borderRadius={4} />
         </Frame>
     ) : null
 })

--- a/pages/tutorial.mdx
+++ b/pages/tutorial.mdx
@@ -78,7 +78,7 @@ We’ve prepared starter files for CodeSandbox and Framer with React and the Fra
 
 <Button
   name="Framer Starter File"
-  link="https://static.framer.com/api/tutorial-start.framerx"
+  link="https://misc.framerstatic.com/api/tutorial-start.framerx"
 />
 
 <br /><br />
@@ -126,7 +126,7 @@ export function App() {
     >
       <Frame
         center
-        image={"https://static.framer.com/api/logo.jpg"}
+        image={"https://misc.framerstatic.com/api/logo.jpg"}
         radius={4}
       />
     </Frame>
@@ -493,7 +493,7 @@ The image `Frame` will be set to `center` and have a scale of 25%. It will also 
     scale={0.25}
     center
     size={480}
-    image={"https://static.framer.com/api/bg.jpg"}
+    image={"https://misc.framerstatic.com/api/bg.jpg"}
   />
   <Slider />
 </Frame>
@@ -821,7 +821,7 @@ Below are completed tutorial files which may be helpful if you ran into any issu
 
 <Button
   name="Framer Completed Tutorial"
-  link="https://static.framer.com/api/tutorial-complete.framerx"
+  link="https://misc.framerstatic.com/api/tutorial-complete.framerx"
 />
 </div>
 <div>


### PR DESCRIPTION
We are moving away from serving unmanaged files on the `framer.com` domain, part of which is migrateing from `static.framer.com` to `misc.framerstatic.com`. The old links will keep on working through a 302 redirect, but let's update all the links.

Ref: https://github.com/framer/company/issues/20653