### PR TITLE
Update `listDelimter` regular expression to not match in-text hyphen in paragraphs

### DIFF
--- a/model/TSDocReactEmitter.ts
+++ b/model/TSDocReactEmitter.ts
@@ -257,7 +257,7 @@ function render<T>(docNode: DocNode | undefined, { createElement, Fragment }: Li
 
         // A chunk of text seperated by two newlines.
         case DocNodeKind.Paragraph:
-            const listDelimiter = /[*-]\s*/
+            const listDelimiter = /(?:\*|-(?!\w))\s*/
             const trimmedParagraph: DocParagraph = DocNodeTransforms.trimSpacesInParagraph(docNode as DocParagraph)
             if (trimmedParagraph.nodes.length === 0) return null
 


### PR DESCRIPTION
## Problem
I noticed in the docs that any hyphen in summary markups for the API methods gets rendered as a list item even when it is inline as part of a method's description.

For example, the note from the [onPan](https://www.framer.com/api/motion/gestures/#pan) gesture (shown below) gets broken down arbitrarily, even removing the hyphen from the referenced URL, making it invalid: `/touch-action` becomes `touchaction`.

## Attempted fix
This small patch updates the regular expression in cause to not match **hyphens followed by a word character** in the `render` method of the `TSDocReactEmitter`.

- Current section in the docs
![image](https://user-images.githubusercontent.com/49351279/124493655-e3f6f900-dd83-11eb-89d7-fc6769541d45.png)

- After this fix
![image](https://user-images.githubusercontent.com/49351279/124493585-d17cbf80-dd83-11eb-90fa-6617c90c0a43.png)