### PR TITLE
Fix typo on animation page

### DIFF
--- a/pages/motion/animation.mdx
+++ b/pages/motion/animation.mdx
@@ -12,7 +12,6 @@ import {
   Template,
   Link,
   Ref,
-  Callout,
   Todo,
 } from "../../components"
 
@@ -411,11 +410,9 @@ If you're not animating these values, the easiest way to do this is to set them 
 <motion.div initial={{ borderRadius: 20 }} />
 ```
 
-<Callout>
-  <strong>Note:</strong> In a future release it'll also be
-  possible to set these styles via `style` and they'll be
-  automatically corrected.
-</Callout>
+<strong>Note:</strong> In a future release it'll also be possible to set these styles via `style` and they'll be automatically corrected.
+
+
 
 ### Customising layout animations
 


### PR DESCRIPTION
Callout wrapper doesn't recognize inline code syntax highlighting.

Might as well remove the Callout import since it's no longer being used on this page.