### PR TITLE
Update the SVG position attribute advice.

### DIFF
--- a/pages/motion/component.mdx
+++ b/pages/motion/component.mdx
@@ -141,7 +141,7 @@ return (
 )
 ```
 
-**SVG note:** For SVG components, `x` and `y` are positional attributes distinct from `translateX` and `translateY`. Using the former will change the element's `x`/`y` attributes, while using the latter will set its `style.transform` property.
+**SVG note:** For SVG components, `x` and `y` are positional attributes distinct from `translateX` and `translateY`. Using the latter or the `x`/`y` translate shortcuts will set the component's `style.transform` property. To instead change the SVG `x`/`y` attributes, use `attrX`/`attrY`.
 
 ### Transform origin
 


### PR DESCRIPTION
I was wanting to animate the `y` attribute on an SVG text element, but found that contrary to the documentation, it resulted in a `translateY` transform animation. I did some searching in the framer/motion repo and found that animating `attrY` was the solution. This PR updates the SVG component note to include this advice. 

