### PR TITLE
Update animate-shared-layout.mdx to match sandbox

### DIFF
--- a/pages/motion/animate-shared-layout.mdx
+++ b/pages/motion/animate-shared-layout.mdx
@@ -145,7 +145,7 @@ In this example, each item contains a `motion` component with a `layoutId="outli
 </div>
 
 ```jsx
-isSelected && <motion.div layoutId="underline" />
+isSelected && <motion.div layoutId="outline" />
 ```
 
 When a new component with a `layoutId` gets added as another gets removed, the component will perform a <Link href="/pages/motion/animation/#layout-animations">layout animation</Link> from previous component.
@@ -154,7 +154,7 @@ The new component will also inherit any animating values from the old component 
 
 ```jsx
 <motion.div
-  layoutId="underline"
+  layoutId="outline"
   initial={false}
   animate={{ backgroundColor: "#ff0000" }}
 />


### PR DESCRIPTION
Hi, just noticed that the interactive codesandbox uses `outline`, while the docs currently use `underline`.

<img width="828" alt="Screen Shot 2022-05-12 at 1 38 11 PM" src="https://user-images.githubusercontent.com/3595986/168163806-720fe7dc-9ca1-4a7e-9631-46217b455454.png">
 